### PR TITLE
Mise à jour de psycopg - 3.1.12

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ humanize==4.8.0
 mjml-python==1.1.0
 model-bakery==1.15.0
 osm_opening_hours==0.1.1
-psycopg2-binary==2.9.7
+psycopg[binary]==3.1.12
 PyJWT==2.6.0
 redis==5.0.0
 requests==2.31.0


### PR DESCRIPTION
- meilleures performances 
- gestion de l'async
- supporté depuis Django 4.2

voir https://docs.djangoproject.com/en/4.2/releases/4.2/#psycopg-3-support