### PR TITLE
Emploi du type de zone `pays`

### DIFF
--- a/dora/api/serializers.py
+++ b/dora/api/serializers.py
@@ -377,7 +377,7 @@ class ServiceSerializer(serializers.ModelSerializer):
         if obj.diffusion_zone_type == "region":
             return "region"
         if obj.diffusion_zone_type == "country":
-            return None
+            return "pays"
 
     def get_zone_diffusion_code(self, obj):
         return obj.diffusion_zone_details


### PR DESCRIPTION
Le schéma data·inclusion propose la valeur explicite `pays` pour les zones de diffusion de type `country`.

Actuellement ça n'est pas utilisé dans l'api et par conséquent les services à diffusion nationale ne sont pas clairement identifiables.