### PR TITLE
MaJ Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.4
+    rev: v0.2.2
     hooks:
       - id: ruff
         name: Ruff (Flake8)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,13 @@
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE="config.settings"
+python_files = ["test.py", "tests*.py", "test_*.py"]
+
 [tool.ruff]
-ignore = ["E501", "E203"]
+target-version = "py311"
 line-length = 88
+
+[tool.ruff.lint]
+ignore = ["E501", "E203"]
 # Compatibilité minimale avec flake8, à faire évoluer si nécessaire
 # voir les règles de lint : https://docs.astral.sh/ruff/rules/
 select = [
@@ -11,12 +18,8 @@ select = [
     "I",  # isort
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["dora"]
-
-[tool.pytest.ini_options]
-DJANGO_SETTINGS_MODULE="config.settings"
-python_files = ["test.py", "tests*.py", "test_*.py"]
 
 # Note : la plupart des éléments de configuration de sqlfluff
 # sont basés sur les recommandantions et usages de Data-Inclusion

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,7 @@ djhtml==3.0.6
 freezegun==1.2.2
 ggshield==1.18.1
 pre-commit==3.4.0
-ruff==0.1.4
+ruff==0.2.2
 pytest==7.4.3
 pytest-django==4.6.0
 sqlfluff==2.3.5


### PR DESCRIPTION
- passage en v0.2.2
- modification de la configuration (deprecation)
- version de Python fixée explicitement (3.11)