### PR TITLE
Retrait de paramètres Django obsolètes

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -197,20 +197,16 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 # Internationalization
-# https://docs.djangoproject.com/en/3.2/topics/i18n/
+# https://docs.djangoproject.com/en/4.2/topics/i18n/
 
 LANGUAGE_CODE = "fr-fr"
 
 TIME_ZONE = "Europe/Paris"
 
-USE_I18N = True
-
-USE_L10N = True
-
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/3.2/howto/static-files/
+# https://docs.djangoproject.com/en/4.2/howto/static-files/
 
 STATIC_URL = "/static/"
 STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")


### PR DESCRIPTION
Visible lors du lancement des tests et de toute façon à `True` par défaut 

voir :
- https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-USE_I18N
- https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-USE_L10N