### PR TITLE
FIX: ajout d'un tracking Matomo manquant

### DIFF
--- a/dora/notifications/tasks/invitations.py
+++ b/dora/notifications/tasks/invitations.py
@@ -63,6 +63,7 @@ class InvitedUsersTask(Task):
                     send_invitation_reminder(
                         notification.owner_structureputativemember.user,
                         notification.owner_structureputativemember.structure,
+                        notification=True,
                     )
                 except Exception as ex:
                     raise TaskError(

--- a/dora/users/emails.py
+++ b/dora/users/emails.py
@@ -7,9 +7,18 @@ from mjml import mjml2html
 from dora.core.emails import send_mail
 
 
-def send_invitation_reminder(user, structure):
+def send_invitation_reminder(user, structure, notification=False):
     cta_link = furl(settings.FRONTEND_URL) / "auth" / "invitation"
     cta_link.add({"login_hint": iri_to_uri(user.email), "structure": structure.slug})
+
+    if notification:
+        cta_link.add(
+            {
+                "mtm_campaign": "MailsTransactionnels",
+                "mtm_keyword": "InvitationaConfirmer",
+            }
+        )
+
     context = {
         "user": user,
         "structure": structure,

--- a/dora/users/tests/test_emails.py
+++ b/dora/users/tests/test_emails.py
@@ -8,11 +8,12 @@ from dora.users.emails import (
 )
 
 
-def test_send_invitation_reminder():
+@pytest.mark.parametrize("with_notification", (True, False))
+def test_send_invitation_reminder(with_notification):
     user = make_user()
     structure = make_structure(putative_member=user)
 
-    send_invitation_reminder(user, structure)
+    send_invitation_reminder(user, structure, notification=with_notification)
 
     assert len(mail.outbox) == 1
     assert mail.outbox[0].to == [user.email]
@@ -22,6 +23,13 @@ def test_send_invitation_reminder():
     )
     assert structure.name in mail.outbox[0].body
     assert "/auth/invitation" in mail.outbox[0].body
+
+    if with_notification:
+        assert "MailsTransactionnels" in mail.outbox[0].body
+        assert "InvitationaConfirmer" in mail.outbox[0].body
+    else:
+        assert "MailsTransactionnels" not in mail.outbox[0].body
+        assert "InvitationaConfirmer" not in mail.outbox[0].body
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Sur la première occurences des notifications aux membres avec rattachements en attente.