### PR TITLE
Modification des tests pour éviter un warning Github

### DIFF
--- a/dora/structures/tests/test_emails.py
+++ b/dora/structures/tests/test_emails.py
@@ -30,8 +30,8 @@ def test_send_orphan_structure_notification():
     assert f"/auth/invitation?structure={structure.slug}" in mail.outbox[0].body
     assert "mtm_campaign=MailsTransactionnels" in mail.outbox[0].body
     assert "mtm_kwd=InvitationStructuresOrphelines" in mail.outbox[0].body
-    assert "https://aide.dora.inclusion.beta.gouv.fr" in mail.outbox[0].body
-    assert "https://app.livestorm.co/dora-1/presentation-dora" in mail.outbox[0].body
+    assert "aide.dora.inclusion.beta.gouv.fr" in mail.outbox[0].body
+    assert "app.livestorm.co/dora-1/presentation-dora" in mail.outbox[0].body
 
 
 def test_send_first_admin_notification_for_pending_invitation():
@@ -51,7 +51,7 @@ def test_send_first_admin_notification_for_pending_invitation():
         assert mail.outbox[idx].subject == "Invitation non acceptée : Action requise"
         assert structure.name in mail.outbox[idx].body
         assert putative_member.email in mail.outbox[idx].body
-        assert "https://aide.dora.inclusion.beta.gouv.fr/" in mail.outbox[idx].body
+        assert "aide.dora.inclusion.beta.gouv.fr" in mail.outbox[idx].body
         assert (
             "gerer-le-compte-de-ses-collaborateurs-en-tant-quadministrateur-xkonvm"
             in mail.outbox[idx].body
@@ -104,7 +104,7 @@ def test_send_admin_self_invited_users_notification():
             urlencode({"next": f"/structures/{structure.slug}/collaborateurs"})
             in mail.outbox[idx].body
         )
-        assert "https://aide.dora.inclusion.beta.gouv.fr/" in mail.outbox[idx].body
+        assert "aide.dora.inclusion.beta.gouv.fr" in mail.outbox[idx].body
         assert (
             "gerer-le-compte-de-ses-collaborateurs-en-tant-quadministrateur-xkonvm"
             in mail.outbox[idx].body
@@ -138,10 +138,8 @@ def test_send_structure_activation_notification_to_old_admins():
         )
         assert "mtm_campaign=MailsTransactionnels" in mail.outbox[idx].body
         assert "mtm_kwd=RelanceActivationService" in mail.outbox[idx].body
-        assert "https://aide.dora.inclusion.beta.gouv.fr" in mail.outbox[idx].body
-        assert (
-            "https://app.livestorm.co/dora-1/presentation-dora" in mail.outbox[idx].body
-        )
+        assert "aide.dora.inclusion.beta.gouv.fr" in mail.outbox[idx].body
+        assert "app.livestorm.co/dora-1/presentation-dora" in mail.outbox[idx].body
 
 
 def test_send_structure_activation_notification_to_other_members():


### PR DESCRIPTION
Le scanner de code est un peu touchy sur les URLs entiers. La modification devrait permettre de le faire taire ...