### PR TITLE
Correction des tests d'import de structures

### DIFF
--- a/dora/core/management/commands/import_structures.py
+++ b/dora/core/management/commands/import_structures.py
@@ -6,7 +6,7 @@ from rest_framework import serializers
 
 from dora.core.models import ModerationStatus
 from dora.core.notify import send_moderation_notification
-from dora.core.validators import validate_full_siret
+from dora.core.validators import validate_siret
 from dora.services.models import ServiceModel
 from dora.services.utils import instantiate_model
 from dora.sirene.models import Establishment
@@ -39,10 +39,8 @@ def to_string_array(strings_list):
 
 class ImportSerializer(serializers.Serializer):
     name = serializers.CharField()
-    siret = serializers.CharField(allow_blank=True, validators=[validate_full_siret])
-    parent_siret = serializers.CharField(
-        allow_blank=True, validators=[validate_full_siret]
-    )
+    siret = serializers.CharField(allow_blank=True, validators=[validate_siret])
+    parent_siret = serializers.CharField(allow_blank=True, validators=[validate_siret])
     admins = serializers.ListField(child=serializers.EmailField(), allow_empty=True)
     labels = serializers.ListField(child=serializers.CharField(), allow_empty=True)
     models = serializers.ListField(child=serializers.CharField(), allow_empty=True)

--- a/dora/core/tests/test_structures_import.py
+++ b/dora/core/tests/test_structures_import.py
@@ -62,7 +62,8 @@ class StructuresImportTestCase(APITestCase):
     def test_invalid_siret_wont_create_anything(self):
         self.add_row(["foo", "1234", "", "foo@buzz.com", "", ""])
         out, err = self.call_command()
-        self.assertIn("Siret invalide", err)
+        self.assertIn("Le numéro SIRET doit être composé de 14 chiffres.", err)
+        self.assertIn("siret", err)
         self.assertFalse(Structure.objects.filter(siret="12345").exists())
         self.assertFalse(User.objects.filter(email="foo@buzz.com").exists())
         self.assertEqual(len(mail.outbox), 0)
@@ -70,12 +71,13 @@ class StructuresImportTestCase(APITestCase):
     def test_invalid_parent_siret_error(self):
         self.add_row(["foo", "", "1234", "foo@buzz.com", "", ""])
         out, err = self.call_command()
-        self.assertIn("Siret parent invalide", err)
+        self.assertIn("Le numéro SIRET doit être composé de 14 chiffres.", err)
+        self.assertIn("parent_siret", err)
 
     def test_unknown_parent_siret_error(self):
         self.add_row(["foo", "", "12345678901234", "foo@buzz.com", "", ""])
         out, err = self.call_command()
-        self.assertIn("Siret parent inconnu", err)
+        self.assertIn("SIRET parent inconnu", err)
 
     def test_missing_siret_error(self):
         self.add_row(["foo", "", "", "foo@buzz.com", "", ""])
@@ -88,7 +90,7 @@ class StructuresImportTestCase(APITestCase):
         self.add_row(["foo", "", "12345678901234", "foo@buzz.com", "", ""])
         out, err = self.call_command()
         self.assertIn(
-            "Le siret 12345678901234 est une antenne, il ne peut pas être utilisé comme parent",
+            "Le SIRET 12345678901234 est une antenne, il ne peut pas être utilisé comme parent",
             err,
         )
 


### PR DESCRIPTION
Les validateurs de SIRET n'avaient pas le même message d'erreur que dans les tests.

"Qui casse paie"