### PR TITLE
Ajout du slug et du SIRET parent pour les antennes

### DIFF
--- a/dora/structures/serializers.py
+++ b/dora/structures/serializers.py
@@ -54,6 +54,9 @@ class StructureSerializer(serializers.ModelSerializer):
 
     source = serializers.SerializerMethodField()
 
+    parent_siret = serializers.SerializerMethodField()
+    parent_slug = serializers.SerializerMethodField()
+
     class Meta:
         model = Structure
         fields = [
@@ -101,13 +104,27 @@ class StructureSerializer(serializers.ModelSerializer):
             "short_desc",
             "siret",
             "slug",
+            "parent_siret",
+            "parent_slug",
             "source",
             "typology",
             "typology_display",
             "url",
         ]
         lookup_field = "slug"
-        read_only_fields = ["has_been_edited", "city", "department"]
+        read_only_fields = [
+            "has_been_edited",
+            "city",
+            "department",
+            "parent_slug",
+            "parent_siret",
+        ]
+
+    def get_parent_siret(self, obj):
+        return obj.parent.siret if obj.parent else None
+
+    def get_parent_slug(self, obj):
+        return obj.parent.slug if obj.parent else None
 
     # TODO: utiliser !!numAdmins coté front pour se débarasser de cette methode
     def get_has_admin(self, obj):


### PR DESCRIPTION
Pour : https://trello.com/c/Sr0U7LmN

Dans la vue de structure cette fois-ci ...
Tests dans un deuxième temps, le temps d'analyser les dépendances entre la vue et le sérialiseur.

![image](https://github.com/gip-inclusion/dora-back/assets/147232/007c0a80-22d5-4076-a2a7-976dcb67dcdc)
