### PR TITLE
config: ajout d'un seuil de log spécifique pour 'dora.logs.core'

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -555,3 +555,17 @@ try:
     NOTIFICATIONS_LIMIT = int(os.environ.get("NOTIFICATIONS_LIMIT", 0))
 except Exception:
     NOTIFICATIONS_LIMIT = 0
+
+# Logging :
+# permettre un niveau de log 'INFO' pour le logger `dora.logs.core`
+# il est également réglable via variable d'environnement, si besoin
+# (le reste de la configuration de logging par défaut n'est pas modifié)
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "loggers": {
+        "dora.logs.core": {
+            "level": os.getenv("DORA_LOGS_CORE_LEVEL", "INFO"),
+        },
+    },
+}


### PR DESCRIPTION
Le niveau de log de Django en production est `WARNING`. 
Celui de debug/dev (`DEBUG=True`) est `INFO`.
Le niveau du logger `dora.logs.core` est désormais `INFO`.