### PR TITLE
HOTFIX: problème de requête ORM

### DIFF
--- a/dora/sirene/views.py
+++ b/dora/sirene/views.py
@@ -45,11 +45,23 @@ def search_sirene(request, citycode):
     )
 
     # Exclut les structures marquées comme obsolètes
-    results = results.exclude(
-        siret__in=Structure.objects.filter(is_obsolete=True).values_list(
-            "siret", flat=True
-        )
+
+    # FIXME :
+    # pour une raison que je n'explique pas encore,
+    # le code original suivant ne fonctionne pas *en production*
+    # mais fonctionne correctement sur un environnement de dev :
+    # results = results.exclude(
+    #     siret__in=Structure.objects.filter(is_obsolete=True).values_list(
+    #         "siret", flat=True
+    #     )
+    # )
+    # la sous-requête ne renvoie rien sur la production,
+    # sauf si on la matérialise via une liste.
+
+    obsolete = Structure.objects.filter(is_obsolete=True).values_list(
+        "siret", flat=True
     )
+    results = results.exclude(siret__in=list(obsolete))
 
     # Exclut les structures sans nom propre, sauf s’il s’agit du siège
     results = results.exclude(name="", is_siege=False)


### PR DESCRIPTION
Cause encore non déterminée.

Voir les commentaires dans le code de la vue de recherche. 

Une sous-requête de l'ORM ne se comporte pas de la même manière sur environnement de dev et celui de production.

