### PR TITLE
Optimisation de la recherche

### DIFF
--- a/dora/data_inclusion/mappings.py
+++ b/dora/data_inclusion/mappings.py
@@ -37,7 +37,7 @@ DI_TO_DORA_DIFFUSION_ZONE_TYPE_MAPPING = {
 # On pourrait tout de même implémenter les mappings avec des serializers basés sur ceux existants.
 
 
-def map_search_result(result: dict) -> dict:
+def map_search_result(result: dict, supported_service_kinds: list[str]) -> dict:
     # On transforme les champs nécessaires à l'affichage des resultats de recherche au format DORA
     # (c.a.d qu'on veut un objet similaire à ce que renvoie le SearchResultSerializer)
 
@@ -49,9 +49,7 @@ def map_search_result(result: dict) -> dict:
         location_kinds = ["en-presentiel"]
 
     kinds = (
-        ServiceKind.objects.filter(value__in=service_data["types"]).values_list(
-            "value", flat=True
-        )
+        filter(lambda kind: kind in supported_service_kinds, service_data["types"])
         if service_data["types"] is not None
         else None
     )

--- a/dora/services/search.py
+++ b/dora/services/search.py
@@ -224,6 +224,8 @@ def _get_dora_results(
         )
         .prefetch_related(
             "kinds",
+            "fee_condition",
+            "location_kinds",
             "categories",
             "subcategories",
         )

--- a/dora/services/search.py
+++ b/dora/services/search.py
@@ -24,13 +24,14 @@ MAX_DISTANCE = 50
 
 
 def _filter_and_annotate_dora_services(services, location, with_remote, with_onsite):
+    no_services = models.Service.objects.none()
     # 1) services ayant un lieu de déroulement, à moins de MAX_DISTANCE km
     services_on_site = (
         services.filter(location_kinds__value="en-presentiel")
         .annotate(distance=Distance("geom", location))
         .filter(distance__lte=D(km=MAX_DISTANCE))
         if with_onsite
-        else []
+        else no_services
     )
     # 2) services sans lieu de déroulement
     services_remote = (
@@ -44,9 +45,9 @@ def _filter_and_annotate_dora_services(services, location, with_remote, with_ons
             .annotate(distance=Value(None, output_field=IntegerField()))
         )
         if with_remote
-        else []
+        else no_services
     )
-    return list(services_on_site) + list(services_remote)
+    return services_on_site | services_remote
 
 
 def _sort_services(services):

--- a/dora/services/search.py
+++ b/dora/services/search.py
@@ -168,8 +168,11 @@ def _get_di_results(
         )
     ]
 
+    supported_service_kinds = models.ServiceKind.objects.values_list("value", flat=True)
+
     mapped_di_results = [
-        data_inclusion.map_search_result(result) for result in raw_di_results
+        data_inclusion.map_search_result(result, supported_service_kinds)
+        for result in raw_di_results
     ]
 
     # FIXME: exclu les services uniquement en présentiel à plus de MAX_DISTANCE


### PR DESCRIPTION
Exemples :

Recherche "Toulouse" sans thématique et sans besoin :
On passe de **1560** requêtes en **3.7825s** à **24** requêtes en **1.1775s**

Recherche "Toulouse" avec une thématique et deux besoins :
On passe de **208** requêtes en **0.6408s** à **24** requêtes en **0.5969s**