### PR TITLE
Correction de la notification d'activation de service

### DIFF
--- a/dora/notifications/tasks/invitations.py
+++ b/dora/notifications/tasks/invitations.py
@@ -117,7 +117,9 @@ class InvitedUsersTask(Task):
                     "legal": True,
                     "userEmail": user.email,
                     "userId": str(user.pk),
-                    "structureId": str(notification.owner_structureputativemember.structure.pk),
+                    "structureId": str(
+                        notification.owner_structureputativemember.structure.pk
+                    ),
                     "reason": "Pas de rattachement à la structure après relances",
                 },
             )

--- a/dora/notifications/tasks/structures.py
+++ b/dora/notifications/tasks/structures.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from dateutil.relativedelta import relativedelta
+from django.db.models import Q
 from django.utils import timezone
 
 from dora.core import constants
@@ -65,7 +66,9 @@ class StructureServiceActivationTask(Task):
         # avec au moins un admin inscrit depuis un mois
         one_month_ago = timezone.now() - relativedelta(months=1)
         return (
-            Structure.objects.exclude(siret__startswith=constants.SIREN_POLE_EMPLOI)
+            Structure.objects.exclude(
+                Q(siret__startswith=constants.SIREN_POLE_EMPLOI) | Q(is_obsolete=True),
+            )
             .filter(
                 services=None,
                 membership__is_admin=True,

--- a/dora/notifications/tasks/tests/tests_structures.py
+++ b/dora/notifications/tasks/tests/tests_structures.py
@@ -117,9 +117,17 @@ def test_structure_services_activation_candidates(
 
     assert not structure_service_activation_task.candidates()
 
-    # structure avec au moins un service
+    # pas de structure obsolète
     structure_with_admin.siret = "50060080000001"
+    structure_with_admin.is_obsolete = True
+    structure_with_admin.save()
+
+    assert not structure_service_activation_task.candidates()
+
+    # structure avec au moins un service
+    structure_with_admin.siret = "50060080000002"
     make_service(structure=structure_with_admin)
+    structure_with_admin.is_obsolete = False
     structure_with_admin.save()
 
     assert not structure_service_activation_task.candidates()


### PR DESCRIPTION
Les structures obsolètes n'étaient pas filtrées.
