### PR TITLE
Modification du rapport pour les gestionnaires

### DIFF
--- a/dora/support/serializers.py
+++ b/dora/support/serializers.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from rest_framework import serializers
 
 from dora.core.models import LogItem, ModerationStatus
-from dora.services.enums import ServiceStatus
 from dora.services.models import Service, ServiceModel
 from dora.services.serializers import ServiceSerializer
 from dora.structures.models import Structure, StructureMember, StructurePutativeMember
@@ -178,8 +177,7 @@ class StructureAdminSerializer(StructureSerializer):
                 model = StructureMember
                 fields = ["user", "is_admin", "creation_date"]
 
-        members = StructureMember.objects.filter(structure=obj)
-        return SMSerializer(members, many=True).data
+        return SMSerializer(obj.membership, many=True).data
 
     def get_pending_members(self, obj):
         class SPMSerializer(serializers.ModelSerializer):
@@ -189,8 +187,7 @@ class StructureAdminSerializer(StructureSerializer):
                 model = StructurePutativeMember
                 fields = ["user", "is_admin", "creation_date", "invited_by_admin"]
 
-        pmembers = StructurePutativeMember.objects.filter(structure=obj)
-        return SPMSerializer(pmembers, many=True).data
+        return SPMSerializer(obj.putative_membership, many=True).data
 
     def get_source(self, obj):
         return obj.source.label if obj.source else ""
@@ -204,15 +201,13 @@ class StructureAdminSerializer(StructureSerializer):
         return {}
 
     def get_branches(self, obj):
-        branches = obj.branches.all()
-
         class BranchSerializer(serializers.ModelSerializer):
             class Meta:
                 model = Structure
                 fields = ["slug", "name", "short_desc"]
                 lookup_field = "slug"
 
-        return BranchSerializer(branches, many=True).data
+        return BranchSerializer(obj.branches.all(), many=True).data
 
     def get_models(self, obj):
         models = ServiceModel.objects.filter(structure=obj)
@@ -226,15 +221,13 @@ class StructureAdminSerializer(StructureSerializer):
         return ModelSerializer(models, many=True).data
 
     def get_services(self, obj):
-        services = Service.objects.filter(structure=obj, status=ServiceStatus.PUBLISHED)
-
         class ServiceSerializer(serializers.ModelSerializer):
             class Meta:
                 model = Service
                 fields = ["slug", "name", "short_desc"]
                 lookup_field = "slug"
 
-        return ServiceSerializer(services, many=True).data
+        return ServiceSerializer(obj.services.published(), many=True).data
 
     def get_notes(self, obj):
         logs = LogItem.objects.filter(structure=obj).order_by("-date")
@@ -244,37 +237,30 @@ class StructureAdminSerializer(StructureSerializer):
         return obj.has_admin()
 
     def get_num_draft_services(self, obj):
-        return Service.objects.draft().filter(structure=obj).count()
+        return obj.services.draft().count()
 
     def get_num_published_services(self, obj):
-        return Service.objects.published().filter(structure=obj).count()
+        return obj.services.published().count()
 
     def get_num_outdated_services(self, obj):
-        return (
-            Service.objects.update_advised()
-            .filter(
-                structure=obj,
-            )
-            .count()
-        )
+        return obj.services.update_advised().count()
 
     def get_num_services(self, obj):
-        return Service.objects.active().filter(structure=obj).count()
+        return obj.services.count()
 
     def get_categories(self, obj):
         return obj.services.values_list("categories__value", flat=True).distinct()
 
     def get_admins(self, obj):
-        admins = StructureMember.objects.filter(
-            structure=obj, is_admin=True, user__is_valid=True, user__is_active=True
+        admins = obj.membership.filter(
+            is_admin=True, user__is_valid=True, user__is_active=True
         )
         return [a.user.email for a in admins]
 
     def get_editors(self, obj):
-        services = Service.objects.published().filter(structure=obj)
         return set(
             s.last_editor.email
-            for s in services
+            for s in obj.services.published()
             if s.last_editor is not None
             and s.last_editor.email != settings.DORA_BOT_USER
         )
@@ -286,8 +272,7 @@ class StructureAdminSerializer(StructureSerializer):
 
     def get_admins_to_remind(self, obj):
         if not obj.has_admin():
-            admins = StructurePutativeMember.objects.filter(
-                structure=obj,
+            admins = obj.putative_membership.filter(
                 is_admin=True,
                 invited_by_admin=True,
                 user__is_active=True,
@@ -296,22 +281,18 @@ class StructureAdminSerializer(StructureSerializer):
         return []
 
     def get_num_potential_members_to_validate(self, obj):
-        members = StructurePutativeMember.objects.filter(
-            structure=obj,
+        return obj.putative_membership.filter(
             invited_by_admin=False,
             user__is_valid=True,
             user__is_active=True,
-        )
-        return len([m.user.email for m in members])
+        ).count()
 
     def get_num_potential_members_to_remind(self, obj):
-        # rapport gestionnaires: les membres potentiels n'ont pas forcément activé leur e-mail
-        members = StructurePutativeMember.objects.filter(
-            structure=obj,
+        # les membres invités n'ont pas forcément validé leur adresse e-mail
+        return obj.putative_membership.filter(
             invited_by_admin=True,
             user__is_active=True,
-        )
-        return len([m.user.email for m in members])
+        ).count()
 
 
 class StructureAdminListSerializer(StructureAdminSerializer):

--- a/dora/support/serializers.py
+++ b/dora/support/serializers.py
@@ -305,10 +305,10 @@ class StructureAdminSerializer(StructureSerializer):
         return len([m.user.email for m in members])
 
     def get_num_potential_members_to_remind(self, obj):
+        # rapport gestionnaires: les membres potentiels n'ont pas forcément activé leur e-mail
         members = StructurePutativeMember.objects.filter(
             structure=obj,
             invited_by_admin=True,
-            user__is_valid=True,
             user__is_active=True,
         )
         return len([m.user.email for m in members])

--- a/dora/support/serializers.py
+++ b/dora/support/serializers.py
@@ -246,7 +246,7 @@ class StructureAdminSerializer(StructureSerializer):
         return obj.services.update_advised().count()
 
     def get_num_services(self, obj):
-        return obj.services.count()
+        return obj.services.active().count()
 
     def get_categories(self, obj):
         return obj.services.values_list("categories__value", flat=True).distinct()

--- a/dora/support/views.py
+++ b/dora/support/views.py
@@ -71,7 +71,16 @@ class StructureAdminViewSet(
         user = self.request.user
         department = self.request.query_params.get("department")
 
-        structures = Structure.objects.all()
+        structures = (
+            Structure.objects.all()
+            .prefetch_related(
+                "membership",
+                "putative_membership",
+                "services",
+            )
+            .select_related("parent")
+        )
+
         if department:
             if user.is_manager:
                 # assuré par StructureAdminPermission


### PR DESCRIPTION
https://trello.com/c/asgCStBL/65-modification-de-lexport-gestionnaire

L'export des gestionnaires de département ne recensait que les utilisateurs invités ayant validé leur e-mail.
On souhaite avoir le nombre de tous les membres en attente (e-mail ou non) pour les relancer.

Au passage, une légère optimisation des requêtes effectuées. 
Encore grandement améliorable, mais avec plus de temps à investir sur le sujet...
