### PR TITLE
Vérifications pour les demandes d'orientation

### DIFF
--- a/dora/orientations/admin.py
+++ b/dora/orientations/admin.py
@@ -20,6 +20,7 @@ class OrientationAdmin(admin.ModelAdmin):
         "prescriber_email",
         "processing_date",
         "status",
+        "orientation_checked",
     )
     list_filter = (
         "status",
@@ -38,10 +39,16 @@ class OrientationAdmin(admin.ModelAdmin):
     inlines = [SentContactEmailInline]
 
     @admin.display(description="e-mail prescripteur")
-    def prescriber_email(self, obj):
+    def prescriber_email(self, obj) -> str:
         if p := obj.prescriber:
             return p.email
         return "-"
+
+    @admin.display(description="vérification")
+    def orientation_checked(self, obj) -> bool:
+        return not bool(check_orientation(obj.pk))
+
+    orientation_checked.boolean = True
 
     def get_object(self, request, obj_id, f):
         # quelques tests pour notifier d'avertissements concernant la demande l'orientation (ou pas)

--- a/dora/orientations/admin.py
+++ b/dora/orientations/admin.py
@@ -1,5 +1,6 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 
+from .checks import check_orientation, format_warnings
 from .models import Orientation, SentContactEmail
 
 
@@ -41,6 +42,13 @@ class OrientationAdmin(admin.ModelAdmin):
         if p := obj.prescriber:
             return p.email
         return "-"
+
+    def get_object(self, request, obj_id, f):
+        # quelques tests pour notifier d'avertissements concernant la demande l'orientation (ou pas)
+        if msgs := check_orientation(obj_id):
+            self.message_user(request, format_warnings(msgs), messages.WARNING)
+
+        return super().get_object(request, obj_id, f)
 
 
 admin.site.register(Orientation, OrientationAdmin)

--- a/dora/orientations/checks.py
+++ b/dora/orientations/checks.py
@@ -73,9 +73,10 @@ def check_structure(orientation: Orientation) -> list:
     result = []
 
     if orientation.service:
-        # pour les services enregistrés sur DORA
-        if orientation.prescriber and orientation.service.structure.is_member(
+        # note : dans ce cas, plus optimisé que de passer par structure.is_member
+        if (
             orientation.prescriber
+            and orientation.prescriber in orientation.service.structure.members
         ):
             result.append(
                 "le prescripteur est membre de la structure proposant le service"
@@ -104,9 +105,10 @@ def check_prescriber(orientation: Orientation) -> list:
         ):
             result.append("la structure du prescripteur n'est pas encore validée")
 
+        # note : dans ce cas, plus optimisé que de passer par structure.is_admin
         if (
             orientation.prescriber_structure.membership.count() == 1
-            and orientation.prescriber_structure.is_admin(orientation.prescriber)
+            and orientation.prescriber in orientation.prescriber_structure.admins
         ):
             result.append(
                 "le prescripteur est le seul membre et administrateur de la structure"
@@ -131,9 +133,8 @@ def check_prescriber(orientation: Orientation) -> list:
     return result
 
 
-def check_orientation(orientation_pk: str) -> list | None:
+def check_orientation(orientation: Orientation) -> list | None:
     try:
-        orientation = Orientation.objects.get(pk=orientation_pk)
         msgs = [
             t(orientation)
             for t in [

--- a/dora/orientations/checks.py
+++ b/dora/orientations/checks.py
@@ -1,0 +1,140 @@
+from difflib import SequenceMatcher
+
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
+from django.utils.http import urlencode
+from django.utils.safestring import mark_safe
+
+from .models import Orientation
+
+"""
+Sécurité : vérifications de conformité de l'orientation
+
+Si des anomalies concernant la validité de l'orientation sont trouvées,
+un rapport est généré (sous forme de `list` contenant les avertissements),
+qui peut être utilisé dans l'admin sous forme de message,
+lors de l'ouverture de l'orientation, par ex.
+
+Les différentes vérifications sont implémentées sous la forme de fonctions `check_...`
+qui prennent en paramètre l'objet `Orientation` à tester.
+"""
+
+
+def check_test(orientation: Orientation) -> list:
+    # vérifie la présence de la chaine 'test' dans certain champs (arrive souvent)
+    result = []
+
+    test_fields = [
+        "beneficiary_last_name",
+        "beneficiary_first_name",
+        "beneficiary_email",
+    ]
+
+    for field_name in test_fields:
+        field_value = getattr(orientation, field_name)
+        if "test" in field_value.lower():
+            result.append(
+                f"chaîne de caractère 'test' dans le champ '{Orientation._meta.get_field(field_name).verbose_name}'"
+            )
+
+    return result
+
+
+def check_similar_fields(orientation: Orientation) -> list:
+    result = []
+    k = 0.75
+
+    matcher = SequenceMatcher(
+        None, orientation.prescriber.email, orientation.beneficiary_email
+    )
+    if matcher.ratio() > k:
+        result.append(
+            "les adresses e-mail du prescripteur et du bénéficiaire sont similaires"
+        )
+
+    matcher.set_seqs(
+        orientation.prescriber.last_name, orientation.beneficiary_last_name
+    )
+    if matcher.ratio() > k:
+        result.append("les noms du prescripteur et du bénéficiaire sont similaires")
+
+    ...
+
+    return result
+
+
+def check_structure(orientation: Orientation) -> list:
+    result = []
+
+    if orientation.service:
+        # pour les services enregistrés sur DORA
+        if orientation.service.structure.is_member(orientation.prescriber):
+            result.append(
+                "le prescripteur est membre de la structure proposant le service"
+            )
+
+        if orientation.service.structure == orientation.prescriber_structure:
+            result.append(
+                "la structure proposant le service est la même que celle du prescripteur"
+            )
+
+    ...
+
+    return result
+
+
+def check_prescriber(orientation: Orientation) -> list:
+    result = []
+
+    if (
+        orientation.prescriber_structure.membership.count() == 1
+        and orientation.prescriber_structure.is_admin(orientation.prescriber)
+    ):
+        result.append(
+            "le prescripteur est le seul membre et administrateur de la structure"
+        )
+
+    if orientation.prescriber.date_joined > timezone.now() - relativedelta(weeks=3):
+        result.append("le prescripteur s'est inscrit récemment (moins de 3 semaines)")
+
+    if result:
+        q = urlencode(
+            {
+                "q": f"{orientation.prescriber.first_name} {orientation.prescriber.last_name} {orientation.prescriber_structure}"
+            }
+        )
+        result.append(
+            f"vérifier les informations du prescripteur en ligne : <a href='https://www.google.com/search?{q}' target='_blank'>via Google</a>"
+        )
+
+    return result
+
+
+def check_orientation(orientation_pk: str) -> list | None:
+    try:
+        orientation = Orientation.objects.get(pk=orientation_pk)
+        msgs = [
+            t(orientation)
+            for t in [
+                check_test,
+                check_similar_fields,
+                check_structure,
+                check_prescriber,
+            ]
+        ]
+        msgs = [f"{msg}" for result in msgs for msg in result]
+        return msgs
+    except Orientation.DoesNotExist:
+        pass
+
+    return None
+
+
+def format_warnings(warnings: list) -> str:
+    # des <li> étaient possibles, mais c'était vraiment trop moche
+    msgs = [f"<p>- {msg}</p>" for msg in warnings]
+    msgs = "".join(msgs)
+
+    return mark_safe(
+        f"<p>Cette demande d'orientation comporte des avertissements :</p><p>{msgs}</p>"
+    )


### PR DESCRIPTION
- Nécessite une vérification "humaine".
- Les avertissements sont visibles dans le détail de la fiche dans l'admin
Django (pour l'instant).
- Basée sur les recommandations d'Andrei, à augmenter ou diminuer au
besoin.

Si ça vous semble une bonne idée générale, je rajoute quelques tests ...

![image](https://github.com/gip-inclusion/dora-back/assets/147232/67650a36-554a-4506-b3c0-f09dfe6fa59b)

