### PR TITLE
fix: utilisation d'un tag unique pour les e-mails de notification

### DIFF
--- a/dora/structures/emails.py
+++ b/dora/structures/emails.py
@@ -179,7 +179,7 @@ def send_orphan_structure_notification(structure):
         f"Votre structure n’a pas encore de membre actif sur DORA ({ structure.name})",
         structure.email,
         mjml2html(render_to_string("notification-orphan-structure.mjml", context)),
-        tags=["orphan-structure"],
+        tags=["notification"],
     )
 
 
@@ -200,6 +200,7 @@ def send_admin_invited_users_20_notification(structure, user):
             mjml2html(
                 render_to_string("notification-invitation-stalled-20.mjml", context)
             ),
+            tags=["notification"],
         )
 
 
@@ -218,6 +219,7 @@ def send_admin_invited_users_90_notification(structure, user):
             mjml2html(
                 render_to_string("notification-invitation-stalled-90.mjml", context)
             ),
+            tags=["notification"],
         )
 
 
@@ -250,6 +252,7 @@ def send_admin_self_invited_users_notification(structure, user):
             mjml2html(
                 render_to_string("notification-self-invited-users.mjml", context)
             ),
+            tags=["notification"],
         )
 
 
@@ -284,5 +287,5 @@ def send_structure_activation_notification(structure):
             mjml2html(
                 render_to_string("notification-service-activation.mjml", context),
             ),
-            tags=["structure-service-activation"],
+            tags=["notification"],
         )

--- a/dora/users/emails.py
+++ b/dora/users/emails.py
@@ -33,6 +33,7 @@ def send_invitation_reminder(user, structure, notification=False):
         f"Rappel : Acceptez l'invitation à rejoindre {structure.name} sur DORA",
         user.email,
         mjml2html(render_to_string("invitation_reminder.mjml", context)),
+        tags=["notification"],
     )
 
 
@@ -65,6 +66,7 @@ def send_user_without_structure_notification(user, deletion=False):
                 context,
             )
         ),
+        tags=["notification"],
     )
 
 
@@ -87,4 +89,5 @@ def send_account_deletion_notification(user):
         "DORA - Suppression prochaine de votre compte",
         user.email,
         mjml2html(render_to_string("notification_account_deletion.mjml", context)),
+        tags=["notification"],
     )


### PR DESCRIPTION
Les tags d'e-mails de notifs étaient soit absents, soit spécifiques.
Maintenant harmonisé avec le tag unique : `notification`.
Si besoin de plus d'information, se référer aux logs (ou en créer).
