### PR TITLE
Utilisation de l'adresse de NO-REPLY comme expéditeur des notifications

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/3.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/3.2/ref/settings/
 """
+
 import logging
 import os
 import random
@@ -293,6 +294,7 @@ CORS_ALLOW_HEADERS = list(default_headers) + [
 # EMAIL SETTINGS #
 ##################
 DEFAULT_FROM_EMAIL = os.environ["DEFAULT_FROM_EMAIL"]
+NO_REPLY_EMAIL = os.environ.get("NO_REPLY_EMAIL", DEFAULT_FROM_EMAIL)
 
 # https://app.tipimail.com/#/app/settings/smtp_and_apis
 

--- a/dora/structures/emails.py
+++ b/dora/structures/emails.py
@@ -179,6 +179,7 @@ def send_orphan_structure_notification(structure):
         f"Votre structure n’a pas encore de membre actif sur DORA ({ structure.name})",
         structure.email,
         mjml2html(render_to_string("notification-orphan-structure.mjml", context)),
+        from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
         tags=["notification"],
     )
 
@@ -200,6 +201,7 @@ def send_admin_invited_users_20_notification(structure, user):
             mjml2html(
                 render_to_string("notification-invitation-stalled-20.mjml", context)
             ),
+            from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
             tags=["notification"],
         )
 
@@ -219,6 +221,7 @@ def send_admin_invited_users_90_notification(structure, user):
             mjml2html(
                 render_to_string("notification-invitation-stalled-90.mjml", context)
             ),
+            from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
             tags=["notification"],
         )
 
@@ -252,6 +255,7 @@ def send_admin_self_invited_users_notification(structure, user):
             mjml2html(
                 render_to_string("notification-self-invited-users.mjml", context)
             ),
+            from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
             tags=["notification"],
         )
 
@@ -287,5 +291,6 @@ def send_structure_activation_notification(structure):
             mjml2html(
                 render_to_string("notification-service-activation.mjml", context),
             ),
+            from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
             tags=["notification"],
         )

--- a/dora/users/emails.py
+++ b/dora/users/emails.py
@@ -33,6 +33,7 @@ def send_invitation_reminder(user, structure, notification=False):
         f"Rappel : Acceptez l'invitation à rejoindre {structure.name} sur DORA",
         user.email,
         mjml2html(render_to_string("invitation_reminder.mjml", context)),
+        from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
         tags=["notification"],
     )
 
@@ -66,6 +67,7 @@ def send_user_without_structure_notification(user, deletion=False):
                 context,
             )
         ),
+        from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
         tags=["notification"],
     )
 
@@ -89,5 +91,6 @@ def send_account_deletion_notification(user):
         "DORA - Suppression prochaine de votre compte",
         user.email,
         mjml2html(render_to_string("notification_account_deletion.mjml", context)),
+        from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
         tags=["notification"],
     )


### PR DESCRIPTION
La variable d'environnement `NO_REPLY_EMAIL` a été ajoutée : 
- sur les projets back et front,
- sur staging et prod.
