### PR TITLE
no-reply: changement de l'adresse FROM pour les invitations

### DIFF
--- a/dora/structures/emails.py
+++ b/dora/structures/emails.py
@@ -33,6 +33,7 @@ def send_invitation_email(member, inviter_name):
         "[DORA] Votre invitation sur DORA",
         member.user.email,
         body,
+        from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
         tags=["invitation"],
     )
 


### PR DESCRIPTION
Passage en `NO-REPLY` (`ne-pas-repondre@`)
