### PR TITLE
Utilise directement la base Sirene géolocalisée par l’INSEE au lieu de la version Etalab

### DIFF
--- a/dora/sirene/management/commands/import_sirene.py
+++ b/dora/sirene/management/commands/import_sirene.py
@@ -5,10 +5,12 @@ import subprocess
 import tempfile
 
 from django.conf import settings
+from django.contrib.gis.geos import Point
 from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.utils import DataError
 
+from dora.core.constants import WGS84
 from dora.sirene.models import Establishment
 
 # Documentation des variables SIRENE : https://www.sirene.fr/static-resources/htm/v_sommaire.htm
@@ -16,6 +18,68 @@ from dora.sirene.models import Establishment
 
 def clean_spaces(string):
     return string.replace("  ", " ").strip()
+
+
+def get_srid_for_insee_code(code_insee):
+    # La géolocalisation dans la base Sirène est stockée dans la projection officielle
+    # de chaque territoire
+    # Référence:
+    # - https://geodesie.ign.fr/contenu/fichiers/documentation/SRCfrance.pdf
+    # - https://github.com/etalab/project-legal/blob/master/projections.json
+    # - https://fr.wikipedia.org/wiki/Code_officiel_g%C3%A9ographique
+    INSEE_TO_PROJ = {
+        # Guadeloupe
+        "971": 5490,
+        # Martinique
+        "972": 5490,
+        # Guyane
+        "973": 2972,
+        # La Réunion
+        "974": 2975,
+        # Saint-Pierre-et-Miquelon
+        "975": 4467,
+        # Mayotte
+        "976": 4471,
+        # Saint-Barthélemy
+        "977": 5490,
+        # Saint-Martin
+        "978": 5490,
+        # Nouvelle-Calédonie
+        "988": 3163,
+    }
+
+    if code_insee[:2] not in ("97", "98"):
+        # France Métropolitaine
+        return 2154
+
+    try:
+        return INSEE_TO_PROJ[code_insee[:3]]
+    except KeyError:
+        # Toutes les correspondances n’ont pas été saisies dans INSEE_TO_PROJ, car
+        # le lien n’est pas aussi simple dans tous les autres territoires et surtout,
+        # ils n’ont pour l’instant pas de structures géolocalisées (excepté une seule entrée
+        # en Polynésie Française, qu’on ignore pour l’instant)
+        print(f"Pas de srid défini pour le code insee {code_insee}")
+        return None
+
+
+def get_coordinates(row):
+    # On trouve dans la base sirene
+    # - des coordonnées nulles
+    # - des coordonnées valant `'[ND]'`, pour les entreprises non diffusibles
+    try:
+        x = float(row["coordonneeLambertAbscisseEtablissement"])
+        y = float(row["coordonneeLambertOrdonneeEtablissement"])
+    except (TypeError, ValueError):
+        return (None, None)
+
+    srid = get_srid_for_insee_code(row["codeCommuneEtablissement"])
+    if srid:
+        geom = Point(x, y, srid=srid)
+        geom.transform(WGS84)
+        return geom.coords
+    else:
+        return (None, None)
 
 
 USE_TEMP_DIR = not settings.DEBUG
@@ -55,23 +119,26 @@ class Command(BaseCommand):
 
         stock_file = the_dir / "StockUniteLegale_utf8.csv"
 
-        establishments_geo_file_url = "https://files.data.gouv.fr/geo-sirene/last/StockEtablissementActif_utf8_geo.csv.gz"
-        gzipped_estab_file = the_dir / "StockEtablissementActif_utf8_geo.csv.gz"
+        establishments_geo_file_url = (
+            "https://files.data.gouv.fr/insee-sirene/StockEtablissement_utf8.zip"
+        )
 
-        if not os.path.exists(gzipped_estab_file):
+        zipped_estab_file = the_dir / "StockEtablissement_utf8.zip"
+
+        if not os.path.exists(zipped_estab_file):
             self.stdout.write(self.style.NOTICE("Downloading establishments file"))
             subprocess.run(
-                ["curl", establishments_geo_file_url, "-o", gzipped_estab_file],
+                ["curl", establishments_geo_file_url, "-o", zipped_estab_file],
                 check=True,
             )
 
             self.stdout.write(self.style.NOTICE("Unzipping establishments file"))
             subprocess.run(
-                ["gzip", "-dk", gzipped_estab_file],
+                ["unzip", zipped_estab_file, "-d", the_dir],
                 check=True,
             )
 
-        estab_file = the_dir / "StockEtablissementActif_utf8_geo.csv"
+        estab_file = the_dir / "StockEtablissement_utf8.csv"
 
         return stock_file, estab_file
 
@@ -115,6 +182,8 @@ class Command(BaseCommand):
         name = self.get_name(row)[:255]
         parent_name = parent_name[:255]
         full_search_text = f"{name} {parent_name}" if name != parent_name else name
+        lon, lat = get_coordinates(row)
+
         return Establishment(
             siren=siren[:9],
             siret=row["siret"][:14],
@@ -129,8 +198,8 @@ class Command(BaseCommand):
             )[:5],
             ape=row["activitePrincipaleEtablissement"][:6],
             is_siege=row["etablissementSiege"] == "true",
-            longitude=row["longitude"] if row["longitude"] else None,
-            latitude=row["latitude"] if row["latitude"] else None,
+            longitude=lon,
+            latitude=lat,
             full_search_text=full_search_text,
         )
 
@@ -174,6 +243,8 @@ class Command(BaseCommand):
                     batch_size = 1_000
                     rows = []
                     for i, row in enumerate(reader):
+                        if row["etatAdministratifEtablissement"] != "A":
+                            continue
                         if (i % batch_size) == 0:
                             prog = round(100 * i / num_establishments)
                             if prog != last_prog:


### PR DESCRIPTION
La version Etalab n’est plus mise à jour depuis mars 2024, suite au changement de format de la base Sirene.