### PR TITLE
deps: MàJ des dépendances de tests et du pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.4.8
     hooks:
       - id: ruff
         name: Ruff (Flake8)
@@ -10,7 +10,7 @@ repos:
         args: [ --check ]
 
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 2.3.5
+    rev: 3.0.7
     hooks:
       - id: sqlfluff-lint
         name: Sqlfluff (postgres)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
-data-inclusion-schema==0.14.0
-dj-database-url==2.1.0
+data-inclusion-schema==0.15.0
+dj-database-url==2.2.0
 Django==4.2.12
 django-cors-headers==4.3.1
 django-csp==3.8
@@ -11,14 +11,14 @@ djangorestframework==3.15.1
 furl==2.1.3
 hiredis==2.3.2
 humanize==4.9.0
-mjml-python==1.3.0
-model-bakery==1.18.0
+mjml-python==1.3.3
+model-bakery==1.18.1
 osm_opening_hours==0.1.1
-psycopg[binary]==3.1.18
+psycopg[binary]==3.1.19
 PyJWT==2.6.0 # conflit avec ggshield sur versions supérieures
-redis==5.0.4
-requests==2.32.0
-sentry-sdk==2.1.1
+redis==5.0.5
+requests==2.32.3
+sentry-sdk==2.5.1
 sib-api-v3-sdk==7.6.0
 Unidecode==1.3.8
 whitenoise==6.6.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,11 +4,11 @@ django-environ==0.11.2
 django-querycount==0.8.3
 django-silk==5.1.0
 djhtml==3.0.6
-freezegun==1.5.0
+freezegun==1.5.1
 ggshield==1.27.0
-pre-commit==3.7.0
-ruff==0.4.3
-pytest==8.2.0
+pre-commit==3.7.1
+ruff==0.4.8
+pytest==8.2.2
 pytest-django==4.8.0
-sqlfluff==3.0.6
+sqlfluff==3.0.7
 requests-mock==1.12.1


### PR DESCRIPTION
- Ne pas oublier de réinstaler le pre-commit (`pre-commit install`),
- à noter que `ggshield` vous renverra une erreur pour l'installation car il nécessite une vielle version de `requests`(que l'on ne downgradera pas).
