### PR TITLE
HOTFIX: la source des services doit être sérialisable en JSON

### DIFF
--- a/dora/services/serializers.py
+++ b/dora/services/serializers.py
@@ -732,7 +732,8 @@ class BookmarkSerializer(BookmarkListSerializer):
                 "city": obj.service.city,
                 "name": obj.service.name,
                 "shortDesc": obj.service.short_desc,
-                "source": obj.service.source,
+                # ServiceSource n'est pas sérialisable en JSON
+                "source": str(obj.service.source),
             }
         else:
             source_di, di_service_id = obj.di_id.split("--")

--- a/dora/services/tests/test_serializers.py
+++ b/dora/services/tests/test_serializers.py
@@ -1,0 +1,20 @@
+import pytest
+
+from dora.core.test_utils import make_published_service
+from dora.services.models import Bookmark, ServiceSource
+from dora.services.serializers import BookmarkSerializer
+
+
+@pytest.fixture
+def service_with_source():
+    ServiceSource(label="a-random-source").save()
+    assert ServiceSource.objects.count() > 0
+    return make_published_service(source=ServiceSource.objects.first())
+
+
+def test_service_bookmark_serialization(service_with_source):
+    bookmark = Bookmark(service=service_with_source)
+    data = BookmarkSerializer(bookmark).data
+
+    # Teste la sérialisation correcte de la source du service
+    assert data["service"]["source"] == service_with_source.source.label


### PR DESCRIPTION
La liste des bookmarks de l'utilisateur ne peut pas s'afficher
autrement.
