### PR TITLE
HOTFIX: Redirection vers les orientations à partir du site d'admin

### DIFF
--- a/dora/orientations/models.py
+++ b/dora/orientations/models.py
@@ -191,7 +191,9 @@ class Orientation(models.Model):
         return f"{settings.FRONTEND_URL}/orientations?token={self.query_id}&h={self.get_query_id_hash()}"
 
     def get_absolute_url(self):
-        return self.get_frontend_url()
+        # utilisé seulement par la fonctionnalité `view_on_site` de l'admin :
+        # doit retourner l'URL "magique"
+        return self.get_magic_link()
 
     def get_frontend_url(self):
         return f"{settings.FRONTEND_URL}/orientations?token={self.query_id}"


### PR DESCRIPTION
Le lien "magique" doit être utilisé pour la redirection.
