### PR TITLE
Modification de l'adresse de retour de certains e-mails en `NO-REPLY`

### DIFF
--- a/dora/services/emails.py
+++ b/dora/services/emails.py
@@ -147,5 +147,6 @@ def send_service_reminder_email(
         "Des mises à jour de votre offre de service sur DORA sont nécessaires",
         recipient_email,
         body,
+        from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
         tags=["services_check"],
     )

--- a/dora/services/management/commands/send_saved_searches_notifications.py
+++ b/dora/services/management/commands/send_saved_searches_notifications.py
@@ -67,6 +67,7 @@ class Command(BaseCommand):
                     mjml2html(
                         render_to_string("saved-search-notification.mjml", context)
                     ),
+                    from_email=("La plateforme DORA", settings.NO_REPLY_EMAIL),
                     tags=["saved-search-notification"],
                 )
 


### PR DESCRIPTION
Sur certains e-mails/notifications envoyés pour les services et suite à
remontée du support.
