### PR TITLE
Modification de l'affichage des contacts publics

### DIFF
--- a/dora/services/models.py
+++ b/dora/services/models.py
@@ -512,12 +512,18 @@ class Service(ModerationMixin, models.Model):
         )
 
     def is_orientable(self):
-        return self.is_orientable_partial_compute and (
+        return self.is_orientable_partial_compute() and (
             self.coach_orientation_modes.filter(
                 Q(value="envoyer-courriel") | Q(value="envoyer-fiche-prescription")
             ).exists()
             or self.beneficiaries_access_modes.filter(value="envoyer-courriel").exists()
         )
+
+    @property
+    def contact_info_filled(self):
+        # L'e-mail et le téléphone peuvent être obfusqués
+        # en mode anonyme / non-connecté (voir AnonymousServiceSerializer).
+        return bool(self.contact_email or self.contact_phone)
 
 
 class ServiceModelManager(models.Manager):

--- a/dora/services/serializers.py
+++ b/dora/services/serializers.py
@@ -269,6 +269,7 @@ class ServiceSerializer(serializers.ModelSerializer):
             "coach_orientation_modes_other",
             "concerned_public",
             "concerned_public_display",
+            "contact_info_filled",
             "contact_email",
             "contact_name",
             "contact_phone",

--- a/dora/services/tests/test_models.py
+++ b/dora/services/tests/test_models.py
@@ -563,3 +563,23 @@ def test_cant_instantiate_models_in_other_structures(api_client):
         {"structure": dest_struct.slug, "model": model.slug, **DUMMY_SERVICE},
     )
     assert 403 == response.status_code
+
+
+def test_is_orientable_with_orientation_form():
+    # fix : les services étaient orientables même si le formulaire
+    # d'orientation était désactivé sur la structure source.
+    structure = make_structure(
+        baker.make("users.User", is_valid=True),
+        disable_orientation_form=False,
+    )
+    service = make_service(
+        structure=structure,
+        status=ServiceStatus.PUBLISHED,
+        contact_email="test@test.com",
+    )
+
+    assert service.is_orientable_partial_compute()
+
+    structure.disable_orientation_form = True
+
+    assert not service.is_orientable_partial_compute()


### PR DESCRIPTION
fix pour : https://trello.com/c/05ZSuGjw/66-modalit%C3%A9s-dorientation-rendre-les-informations-de-contacts-publiques-oui-visibles-pour-tous

- **model: ajout d'une propriété et fix `is_orientable`**
- **serializer: ajout du champ `contact_info_filled`**
