### PR TITLE
CI: ajout d'un dependabot explicite

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "requirement"
+      prefix-development: "dev requirement"


### PR DESCRIPTION
# Configuration dependabot

Pour effectuer les MaJ des fichiers `requirements`, en plus des vérifications de sécurité
effectuées par défaut.

Permet aussi de mettre à jour les actions Github utilisées par la CI.

