### PR TITLE
HOTFIX: le champ `contact_info_filled` n'est pas un champ natif des services D·I

### DIFF
--- a/dora/data_inclusion/mappings.py
+++ b/dora/data_inclusion/mappings.py
@@ -245,7 +245,10 @@ def map_service(service_data: dict, is_authenticated: bool) -> dict:
         "contact_phone": service_data["telephone"]
         if service_data["contact_public"] or is_authenticated
         else None,
-        "contact_info_filled": service_data["contact_info_filled"],
+        # double implémentation de cette valeur métier (voir modèle du service DORA) 😩
+        "contact_info_filled": bool(
+            service_data["courriel"] or service_data["telephone"]
+        ),
         "creation_date": service_data["date_creation"],
         "credentials": service_data["justificatifs"],
         "credentials_display": service_data["justificatifs"],


### PR DESCRIPTION
Impacte : [cette PR front](https://github.com/gip-inclusion/dora-front/pull/425) et la visualisation de service D·I
Ce champ doit être recalculé lors du mapping, après récupération des données.
Cette valeur métier est implémentée à 2 endroits (présente dans le
modèle de service DORA).
