### PR TITLE
Mise à jour de Django vers la version 4.2.15

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 data-inclusion-schema==0.16.0
 dj-database-url==2.2.0
-Django==4.2.14
+Django==4.2.15
 django-cors-headers==4.4.0
 django-csp==3.8
 django-filter==24.3


### PR DESCRIPTION
Màj de sécurité essentiellement :
https://docs.djangoproject.com/en/dev/releases/4.2.15/#django-4-2-15-release-notes
