### PR TITLE
Remplacement de GGShield par Talisman

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,13 @@
 /staticfiles
 __pycache__
 .DS_Store
-/envs/dev.env
-/envs/secrets.env
+/envs/*
 .cache_ggshield
 .idea
 .vscode
 *.rdb
 docker-compose.yml
+talisman_report
+.env
+.envrc
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,29 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.8
+    rev: v0.5.7
     hooks:
       - id: ruff
         name: Ruff (Flake8)
-        args: [ --fix ]
+        args: [--fix]
       - id: ruff-format
         name: Ruff format (Black + isort)
-        args: [ --check ]
+        args: [--check]
 
   - repo: https://github.com/sqlfluff/sqlfluff
-    rev: 3.0.7
+    rev: 3.1.0
     hooks:
       - id: sqlfluff-lint
         name: Sqlfluff (postgres)
 
-  - repo: https://github.com/gitguardian/ggshield
-    rev: v1.18.1
+  - repo: https://github.com/thoughtworks/talisman
+    rev: v1.32.0
     hooks:
-      - id: ggshield
-        language_version: python3
-        stages: [ commit ]
+      - id: talisman-commit
+        name: Talisman
+        entry: cmd --githook pre-commit
 
   - repo: https://github.com/rtts/djhtml
-    rev: '3.0.6'
+    rev: 3.0.6
     hooks:
       - id: djhtml
         types: [file]

--- a/README.md
+++ b/README.md
@@ -114,3 +114,7 @@ export DJANGO_SETTINGS_MODULE=config.settings.dev
 # Installer les hooks de pre-commit:
 pre-commit install
 ```
+
+Le pre-commit du projet nécessite une installation locale sur le poste de dev de Talisman (en remplacement de GGShield).
+Voir [la procédure d'installation](https://github.com/thoughtworks/talisman?tab=readme-ov-file#installation).
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,5 +2,4 @@
 
 django-extensions==3.2.3
 django-silk==5.1.0
-ggshield==1.27.0
 pre-commit==3.7.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@ django-environ==0.11.2
 django-querycount==0.8.3
 djhtml==3.0.6
 freezegun==1.5.1
-ruff==0.4.8
+ruff==0.5.7
 pytest==8.2.2
 pytest-django==4.8.0
 sqlfluff==3.1.0


### PR DESCRIPTION
voir : https://trello.com/c/KSg3rLpD/158-remplacer-ggshield-par-talisman

GGShield mets la grouille partout où il passe, essentiellement en bloquant des dépendances du projet sur des versions obsolètes (dans le meilleur des cas) ou en créant des conflits (pour le pire).

Cette PR propose une MaJ vers Talisman, qui propose les mêmes fonctionnalités, sans problèmes de dépendances Python.

De plus Talisman est complètement libre et ne nécessite pas de clé d’utilisation (et au passage on supprime un peu de config).
Pour bien faire :
    - installer **Talisman** en remplacement sur tous les postes de dev : [Github de Talisman](https://github.com/thoughtworks/talisman)
    - activer les `pre-commit` Talisman en lieu et place de ggshield
    - supprimer les dépendances à ggshield
    - maj `pyjwt` et `requests` dans un 2e temps


- **pre-commit: maj des version + ajout de talisman**
- **gitignore: exclusion des rapports talisman**
- **deps: suppression de ggshield**
- **deps: maj ruff**
