### PR TITLE
Ajout de labels nationaux "restreints"

### DIFF
--- a/dora/structures/constants.py
+++ b/dora/structures/constants.py
@@ -1,0 +1,18 @@
+from data_inclusion.schema import Typologie
+
+"""
+Valeurs métiers communes à l'app 'dora.structure'.
+Aurait eu sa place dans un module `enums`, mais désormais DORA réutilise
+autant que possible les énumérations du schéma D·I.
+"""
+
+
+# On indique ici les typologies qui ne doivent pas être modifiables par l'utilisateur.
+RESTRICTED_STRUCTURE_TYPOLOGIES = (Typologie.FT,)
+
+# On indique ici les labels nationaux faisant l'objet d'une curation
+# et de restrictions particulières (FT, CapEmploi, partenaires régionaux).
+# Note / TODO :
+# ce sont des `EnumModel`, donc pas de typage.
+# Il serait intéressant de les avoir sous forme de fixture.
+RESTRICTED_NATIONAL_LABELS = ("adie", "cap-emploi-reseau-cheops", "france-travail")

--- a/dora/structures/migrations/0052_add_some_national_labels.py
+++ b/dora/structures/migrations/0052_add_some_national_labels.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
         # Mise à jour de CAP emploi
         cap_emploi = StructureNationalLabel.objects.filter(value="cheops").first()
         if cap_emploi:
-            cap_emploi.value = "cap-emploi-cheops"
+            cap_emploi.value = "cap-emploi-reseau-cheops"
             cap_emploi.label = "CAP Emploi - Réseau CHEOPS"
             cap_emploi.save()
 

--- a/dora/structures/tests/test_structures.py
+++ b/dora/structures/tests/test_structures.py
@@ -4,6 +4,7 @@ from rest_framework.test import APITestCase
 
 from dora.core.test_utils import make_service, make_structure
 from dora.services.enums import ServiceStatus
+from dora.structures.constants import RESTRICTED_NATIONAL_LABELS
 from dora.structures.models import (
     Structure,
     StructureMember,
@@ -1201,3 +1202,23 @@ class StructureMemberTestCase(APITestCase):
         self.assertGreater(len(mail.outbox), 0)
         self.assertIn("Demande d’accès à votre structure", mail.outbox[0].subject)
         self.assertIn(self.my_struct.slug, mail.outbox[0].body)
+
+
+# Tests au format pytest
+
+
+def test_restricted_national_labels(api_client):
+    # On s'assure que la liste des options contient
+    # les label nationaux sélectionnables "restreints"
+    response = api_client.get("/structures-options", follow=True)
+    data = response.json()
+
+    assert (
+        "restrictedNationalLabels" in data.keys()
+    ), "Les labels restreints ne sont pas dans les options"
+
+    values = [lbl.get("value") for lbl in data["restrictedNationalLabels"]]
+
+    assert (
+        tuple(values) == RESTRICTED_NATIONAL_LABELS
+    ), "la liste des labels restreints est incorrecte"

--- a/dora/structures/views.py
+++ b/dora/structures/views.py
@@ -11,6 +11,7 @@ from dora.core.models import ModerationStatus
 from dora.core.notify import send_moderation_notification
 from dora.core.pagination import OptionalPageNumberPagination
 from dora.services.enums import ServiceStatus
+from dora.structures.constants import RESTRICTED_NATIONAL_LABELS
 from dora.structures.emails import send_invitation_email
 from dora.structures.models import (
     Structure,
@@ -344,15 +345,19 @@ def siret_was_claimed(request, siret):
 @api_view()
 @permission_classes([permissions.AllowAny])
 def options(request):
+    labels = StructureNationalLabel.objects.all().order_by("label")
     result = {
         "typologies": Typologie.as_dict_list(),
-        "national_labels": [
-            {"value": c.value, "label": c.label}
-            for c in StructureNationalLabel.objects.all().order_by("label")
-        ],
+        "national_labels": [{"value": c.value, "label": c.label} for c in labels],
         "sources": [
             {"value": c.value, "label": c.label}
             for c in StructureSource.objects.all().order_by("label")
+        ],
+        # les labels nationaux font l'objet d'une curation : voir `.constants`
+        "restricted_national_labels": [
+            {"value": c.value, "label": c.label}
+            for c in labels
+            if c.value in RESTRICTED_NATIONAL_LABELS
         ],
     }
     return Response(result)


### PR DESCRIPTION
voir : https://trello.com/c/CVlvfhYh/153-ajouter-label-ft-sur-structures

Certains labels nationaux ne doivent pas pouvoir être modifiés ou ajoutés lors de la modification d'une structure par un utilisateur.
Il continuent d'être utilisés normalement pour les filtres de recherches ou l'affichage.

Les labels en question (Adie, Cap Emploi - réseau Chéops, France Travail) ont été ajoutés dans `dora.structure.constants.RESTRICTED_NATIONAL_LABELS`.

> [!NOTE]
> il y a une partie front à cette fonctionnalité : https://github.com/gip-inclusion/dora-front/pull/438

