### PR TITLE
Mise à jour du CRON de synchronisation de la base data warehouse utilisée par Metabase

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,7 +1,7 @@
 {
   "jobs": [
     {
-      "command": "17 07-18 * * * tools/update-metabase-db.sh",
+      "command": "0 6,13 * * * tools/update-metabase-db.sh",
       "size": "S"
     },
     {


### PR DESCRIPTION
### 🍣 Problème

Il semblerait que le fait de recréer la base de data-warehouse dont se sert Metabase le mette en PLS.

Le script update-metabase-db.sh détruit pour la recréer la base toutes les heures. Ca force Metabase à refaire tout plein de calculs couteux (scans, fingerprinting, caching) alors qu'on n'a pas besoin d'une telle fraicheur des données.

### Solution

L'objet de cette PR est de modifier la stratégie de synchronisation, de passer de "toutes les heures ouvrées" (entre 7h00 et 18h00) à "2 fois par jour (à 6h00 et 13h00)" pour voir si ça soulage notre cher Metabase.