### PR TITLE
API v2 ServiceSerializer: on ne filtre plus les sous-catégories --autre

### DIFF
--- a/dora/api/serializers.py
+++ b/dora/api/serializers.py
@@ -277,8 +277,7 @@ class ServiceSerializer(serializers.ModelSerializer):
         return [k.value for k in obj.kinds.all()]
 
     def get_thematiques(self, obj):
-        scats = [scat.value for scat in obj.subcategories.all()]
-        return [scat for scat in scats if not scat.endswith("--autre")]
+        return [scat.value for scat in obj.subcategories.all()]
 
     def get_prise_rdv(self, obj):
         return obj.appointment_link

--- a/dora/api/tests.py
+++ b/dora/api/tests.py
@@ -403,25 +403,3 @@ def test_service_serialization_exemple_need_di_user(api_client):
     response = api_client.get(f"/api/v2/services/{service.id}/")
 
     assert 401 == response.status_code
-
-
-def test_subcategories_other_excluded(authenticated_user, api_client):
-    # Example adapté de la doc data·inclusion :
-    # https://www.data.inclusion.beta.gouv.fr/schemas-de-donnees-de-loffre/schema-des-structures-et-services-dinsertion
-    structure = make_structure()
-    service = make_service(
-        structure=structure,
-        name="TISF",
-        short_desc="Accompagnement des familles à domicile",
-        fee_details="",
-        status=ServiceStatus.PUBLISHED,
-    )
-    service.subcategories.add(
-        ServiceSubCategory.objects.get(value="numerique--acceder-a-du-materiel")
-    )
-    service.subcategories.add(ServiceSubCategory.objects.get(value="numerique--autre"))
-
-    response = api_client.get(f"/api/v2/services/{service.id}/")
-
-    assert 200 == response.status_code
-    assert response.json().get("thematiques") == ["numerique--acceder-a-du-materiel"]


### PR DESCRIPTION
DI fait dorénavant lui-même la transformation. On ne filtre donc plus les sous-catégories se terminant par `--autre`.

Le test de ce filtrage a été supprimé.

https://trello.com/c/aLeDF7Gj/199-di-x-dora-api-ne-renvoi-pas-les-th%C3%A9matiques-dun-service#comment-66f513ee9701b3ba18cf1193