### PR TITLE
Correspondance schéma d·i - profils et besoins pour thématiques logement-hebergement

### DIFF
--- a/dora/data_inclusion/client.py
+++ b/dora/data_inclusion/client.py
@@ -7,6 +7,8 @@ import furl
 import requests
 from django.conf import settings
 
+from .constants import THEMATIQUES_MAPPING_DORA_TO_DI
+
 logger = logging.getLogger(__name__)
 
 
@@ -120,7 +122,12 @@ class DataInclusionClient:
             url.args["code_insee"] = code_insee
 
         if thematiques is not None:
-            url.args["thematiques"] = thematiques
+            enriched_thematiques = []
+            for thematique in thematiques:
+                enriched_thematiques += THEMATIQUES_MAPPING_DORA_TO_DI.get(
+                    thematique, [thematique]
+                )
+            url.args["thematiques"] = enriched_thematiques
 
         if types is not None:
             url.args["types"] = types

--- a/dora/data_inclusion/constants.py
+++ b/dora/data_inclusion/constants.py
@@ -9,6 +9,8 @@ THEMATIQUES_MAPPING_DI_TO_DORA = {
 # À une thématique Dora correspond une liste de thématiques DI
 THEMATIQUES_MAPPING_DORA_TO_DI = {}
 for key, value in THEMATIQUES_MAPPING_DI_TO_DORA.items():
+    if value.endswith("--autre"):
+        continue
     if value not in THEMATIQUES_MAPPING_DORA_TO_DI:
         THEMATIQUES_MAPPING_DORA_TO_DI[value] = [key]
     else:

--- a/dora/data_inclusion/constants.py
+++ b/dora/data_inclusion/constants.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 # À une thématique DI correspond une thématique Dora
 THEMATIQUES_MAPPING_DI_TO_DORA = {
     "logement-hebergement--etre-accompagne-dans-son-projet-accession": "logement-hebergement--etre-accompagne-pour-se-loger",
@@ -7,11 +9,7 @@ THEMATIQUES_MAPPING_DI_TO_DORA = {
 
 # Inversion du dictionnaire
 # À une thématique Dora correspond une liste de thématiques DI
-THEMATIQUES_MAPPING_DORA_TO_DI = {}
+THEMATIQUES_MAPPING_DORA_TO_DI = defaultdict(list)
 for key, value in THEMATIQUES_MAPPING_DI_TO_DORA.items():
-    if value.endswith("--autre"):
-        continue
-    if value not in THEMATIQUES_MAPPING_DORA_TO_DI:
-        THEMATIQUES_MAPPING_DORA_TO_DI[value] = [key]
-    else:
+    if not value.endswith("--autre"):
         THEMATIQUES_MAPPING_DORA_TO_DI[value].append(key)

--- a/dora/data_inclusion/constants.py
+++ b/dora/data_inclusion/constants.py
@@ -1,0 +1,5 @@
+THEMATIQUES_MAPPING = {
+    "logement-hebergement--etre-accompagne-dans-son-projet-accession": "logement-hebergement--etre-accompagne-pour-se-loger",
+    "logement-hebergement--etre-accompagne-en cas-de-difficultes-financieres": "logement-hebergement--gerer-son-budget",
+    "logement-hebergement--financer-son-projet-travaux": "logement-hebergement--autre",
+}

--- a/dora/data_inclusion/constants.py
+++ b/dora/data_inclusion/constants.py
@@ -1,5 +1,15 @@
-THEMATIQUES_MAPPING = {
+# À une thématique DI correspond une thématique Dora
+THEMATIQUES_MAPPING_DI_TO_DORA = {
     "logement-hebergement--etre-accompagne-dans-son-projet-accession": "logement-hebergement--etre-accompagne-pour-se-loger",
     "logement-hebergement--etre-accompagne-en cas-de-difficultes-financieres": "logement-hebergement--gerer-son-budget",
     "logement-hebergement--financer-son-projet-travaux": "logement-hebergement--autre",
 }
+
+# Inversion du dictionnaire
+# À une thématique Dora correspond une liste de thématiques DI
+THEMATIQUES_MAPPING_DORA_TO_DI = {}
+for key, value in THEMATIQUES_MAPPING_DI_TO_DORA.items():
+    if value not in THEMATIQUES_MAPPING_DORA_TO_DI:
+        THEMATIQUES_MAPPING_DORA_TO_DI[value] = [key]
+    else:
+        THEMATIQUES_MAPPING_DORA_TO_DI[value].append(key)

--- a/dora/data_inclusion/mappings.py
+++ b/dora/data_inclusion/mappings.py
@@ -16,7 +16,7 @@ from dora.services.models import (
     get_update_status,
 )
 
-from .constants import THEMATIQUES_MAPPING
+from .constants import THEMATIQUES_MAPPING_DI_TO_DORA
 
 DI_TO_DORA_DIFFUSION_ZONE_TYPE_MAPPING = {
     "commune": "city",
@@ -117,7 +117,7 @@ def map_service(service_data: dict, is_authenticated: bool) -> dict:
     subcategories = None
     if service_data["thematiques"] is not None:
         thematiques = [
-            THEMATIQUES_MAPPING.get(thematique, thematique)
+            THEMATIQUES_MAPPING_DI_TO_DORA.get(thematique, thematique)
             for thematique in service_data["thematiques"]
         ]
         categories = ServiceCategory.objects.filter(value__in=thematiques)

--- a/dora/data_inclusion/mappings.py
+++ b/dora/data_inclusion/mappings.py
@@ -16,6 +16,8 @@ from dora.services.models import (
     get_update_status,
 )
 
+from .constants import THEMATIQUES_MAPPING
+
 DI_TO_DORA_DIFFUSION_ZONE_TYPE_MAPPING = {
     "commune": "city",
     "epci": "epci",
@@ -114,12 +116,12 @@ def map_service(service_data: dict, is_authenticated: bool) -> dict:
     categories = None
     subcategories = None
     if service_data["thematiques"] is not None:
-        categories = ServiceCategory.objects.filter(
-            value__in=service_data["thematiques"]
-        )
-        subcategories = ServiceSubCategory.objects.filter(
-            value__in=service_data["thematiques"]
-        )
+        thematiques = [
+            THEMATIQUES_MAPPING.get(thematique, thematique)
+            for thematique in service_data["thematiques"]
+        ]
+        categories = ServiceCategory.objects.filter(value__in=thematiques)
+        subcategories = ServiceSubCategory.objects.filter(value__in=thematiques)
 
     location_kinds = None
     if service_data["modes_accueil"] is not None:

--- a/dora/data_inclusion/test_utils.py
+++ b/dora/data_inclusion/test_utils.py
@@ -1,6 +1,8 @@
 from typing import Optional
 from uuid import uuid4
 
+from .constants import THEMATIQUES_MAPPING_DORA_TO_DI
+
 
 def make_di_service_data(**kwargs) -> dict:
     return {
@@ -99,13 +101,18 @@ class FakeDataInclusionClient:
             services = [r for r in services if r["source"] in sources]
 
         if thematiques is not None:
+            enriched_thematiques = []
+            for thematique in thematiques:
+                enriched_thematiques += THEMATIQUES_MAPPING_DORA_TO_DI.get(
+                    thematique, [thematique]
+                )
             services = [
                 r
                 for r in services
                 if any(
                     t.startswith(requested_thematique)
                     for t in r["thematiques"]
-                    for requested_thematique in thematiques
+                    for requested_thematique in enriched_thematiques
                 )
             ]
 

--- a/dora/data_inclusion/tests.py
+++ b/dora/data_inclusion/tests.py
@@ -1,6 +1,6 @@
-from .constants import THEMATIQUES_MAPPING_DI_TO_DORA
+from .constants import THEMATIQUES_MAPPING_DI_TO_DORA, THEMATIQUES_MAPPING_DORA_TO_DI
 from .mappings import map_service
-from .test_utils import make_di_service_data
+from .test_utils import FakeDataInclusionClient, make_di_service_data
 
 
 def test_map_service_thematiques_mapping():
@@ -21,3 +21,16 @@ def test_map_service_thematiques_mapping():
 
     assert sorted(service["categories"]) == sorted(expected_categories)
     assert sorted(service["subcategories"]) == sorted(expected_subcategories)
+
+
+def test_di_client_search_thematiques_mapping():
+    input_thematique = list(THEMATIQUES_MAPPING_DORA_TO_DI.keys())[0]
+    output_thematique = list(THEMATIQUES_MAPPING_DORA_TO_DI.values())[0][0]
+
+    di_client = FakeDataInclusionClient()
+    di_service_data = make_di_service_data(thematiques=[output_thematique])
+    di_client.services.append(di_service_data)
+
+    results = di_client.search_services(thematiques=[input_thematique])
+
+    assert len(results) == 1

--- a/dora/data_inclusion/tests.py
+++ b/dora/data_inclusion/tests.py
@@ -1,0 +1,23 @@
+from .constants import THEMATIQUES_MAPPING_DI_TO_DORA
+from .mappings import map_service
+from .test_utils import make_di_service_data
+
+
+def test_map_service_thematiques_mapping():
+    input_thematiques = [
+        "logement-hebergement",
+        "logement-hebergement--connaissance-de-ses-droits-et-interlocuteurs",
+        "logement-hebergement--besoin-dadapter-mon-logement",
+    ] + list(THEMATIQUES_MAPPING_DI_TO_DORA.keys())
+
+    expected_categories = ["logement-hebergement"]
+    expected_subcategories = [
+        "logement-hebergement--connaissance-de-ses-droits-et-interlocuteurs",
+        "logement-hebergement--besoin-dadapter-mon-logement",
+    ] + list(THEMATIQUES_MAPPING_DI_TO_DORA.values())
+
+    di_service_data = make_di_service_data(thematiques=input_thematiques)
+    service = map_service(di_service_data, False)
+
+    assert set(service["categories"]) == set(expected_categories)
+    assert set(service["subcategories"]) == set(expected_subcategories)

--- a/dora/data_inclusion/tests.py
+++ b/dora/data_inclusion/tests.py
@@ -19,5 +19,5 @@ def test_map_service_thematiques_mapping():
     di_service_data = make_di_service_data(thematiques=input_thematiques)
     service = map_service(di_service_data, False)
 
-    assert set(service["categories"]) == set(expected_categories)
-    assert set(service["subcategories"]) == set(expected_subcategories)
+    assert sorted(service["categories"]) == sorted(expected_categories)
+    assert sorted(service["subcategories"]) == sorted(expected_subcategories)


### PR DESCRIPTION
Correspondance de thématiques dans les deux sens via les constantes `THEMATIQUES_MAPPING_DI_TO_DORA` et `THEMATIQUES_MAPPING_DORA_TO_DI`.

Utilisation par `map_service()`, `DataInclusionClient.search_services()` et `FakeDataInclusionClient.search_services()`.

Ajout de tests.