### PR TITLE
perf: add Metabase questions on dashboard "Objectifs"

### DIFF
--- a/queries/metabase/03-questions/0110_q_structureviews_by_monthyear_department.sql
+++ b/queries/metabase/03-questions/0110_q_structureviews_by_monthyear_department.sql
@@ -1,0 +1,22 @@
+-- Question(s) concernée(s):
+--   • "Nombre de vues de fiches structure"
+
+drop table if exists q_structureviews_by_monthyear_department;
+
+create table q_structureviews_by_monthyear_department as (
+    select
+        mb_user.department                    as "department",
+        date_trunc('month', struct_view.date) as "period",
+        count(*)                              as "count"
+    from stats_structureview as struct_view
+    left join mb_user on struct_view.user_id = mb_user.id
+    where
+        struct_view.is_structure_member = false
+        and struct_view.is_structure_admin = false
+        and struct_view.is_staff = false
+    group by
+        date_trunc('month', struct_view.date),
+        mb_user.department
+    order by
+        date_trunc('month', struct_view.date) asc
+);

--- a/queries/metabase/03-questions/0120_q_serviceviews_by_monthyear_department.sql
+++ b/queries/metabase/03-questions/0120_q_serviceviews_by_monthyear_department.sql
@@ -1,0 +1,21 @@
+-- Question(s) concernée(s):
+--   • "Vues d'un service dora avec infos de contact publiques"
+
+drop table if exists q_serviceviews_by_monthyear_department;
+
+create table q_serviceviews_by_monthyear_department as (
+    select
+        serv_view.structure_department      as "department",
+        date_trunc('month', serv_view.date) as "period",
+        count(*)                            as "count"
+    from stats_serviceview as serv_view
+    left join mb_service as serv on serv_view.service_id = serv.id
+    where
+        serv_view.is_logged = false
+        and serv.is_contact_info_public = true
+    group by
+        date_trunc('month', serv_view.date),
+        serv_view.structure_department
+    order by
+        date_trunc('month', serv_view.date) asc
+);


### PR DESCRIPTION
### 🍣 Problème

Le tableau de bord "Objectifs 2024" est extrêmement lent ou ne s'affiche jamais. 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/93ad4af4-2717-4228-94a2-39d33c227d2b">

### 🦄 Solution

Ajouter des scripts SQL pour créer des tables dérivées : 
* 0110_q_structureviews_by_monthyear_department.sql → +1mn05s (au processus de synchronisation)
* 0120_q_serviceviews_by_monthyear_department.sql  → +25s