### PR TITLE
Fix: correction des doublons de données Metabase

### DIFF
--- a/queries/metabase/01-base/0130_mb_stats_searchview.sql
+++ b/queries/metabase/01-base/0130_mb_stats_searchview.sql
@@ -1,4 +1,4 @@
-drop table if exists mb_stats_searchview;
+drop table if exists mb_stats_searchview cascade;
 
 create table mb_stats_searchview as
 select

--- a/queries/metabase/01-base/0140_mb_stats_structureview.sql
+++ b/queries/metabase/01-base/0140_mb_stats_structureview.sql
@@ -1,4 +1,4 @@
-drop table if exists mb_stats_structureview;
+drop table if exists mb_stats_structureview cascade;
 
 create table mb_stats_structureview as
 select

--- a/queries/stats/01-utilisateurs/0010_v_searches_for_user.sql
+++ b/queries/stats/01-utilisateurs/0010_v_searches_for_user.sql
@@ -3,7 +3,7 @@
 -- non-membre de l'équipe, 
 -- et non-offreur seulement. 
 
-drop view v_searches_for_user;
+drop view if exists v_searches_for_user;
 
 create or replace view v_searches_for_user as
 select

--- a/queries/stats/01-utilisateurs/0011_v_service_views_for_user.sql
+++ b/queries/stats/01-utilisateurs/0011_v_service_views_for_user.sql
@@ -4,7 +4,7 @@
 -- pas porté par une structure dont l'utilisateur est membre,
 -- et non-offreur seulement. 
 
-drop view v_service_views_for_user;
+drop view if exists v_service_views_for_user;
 
 create or replace view v_service_views_for_user as
 select

--- a/queries/stats/01-utilisateurs/0012_v_structure_views_for_user.sql
+++ b/queries/stats/01-utilisateurs/0012_v_structure_views_for_user.sql
@@ -4,7 +4,7 @@
 -- pas une structure dont l'utilisateur est membre,
 -- et non-offreur seulement. 
 
-drop view v_structure_views_for_user;
+drop view if exists v_structure_views_for_user;
 
 create or replace view v_structure_views_for_user as
 select

--- a/tools/update-metabase-db.sh
+++ b/tools/update-metabase-db.sh
@@ -1,16 +1,42 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
+# Couleurs ANSI
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color (reset)
+
 # Vérification de la présence du endpoint Metabase dans l'environnement 
 if [ -z "$METABASE_DB_URL" ];then echo "Pas de serveur Metabase connu ; export abandonné."; exit 0; fi
 
-# Installe la dernière version de psql 
+echo -e "${CYAN}→ Installation de la dernière version de \`psql\`${NC}"
 dbclient-fetcher psql
+echo " "
 
-# Installe et exporte les requêtes SQL du dossier `queries` 
+echo -e "${CYAN}→ Désactive les messages de niveau \"NOTICE\"${NC}"
+psql $METABASE_DB_URL -c "SET client_min_messages TO WARNING;"
+echo " "
+
+echo -e "${CYAN}→ Installation et export des requêtes SQL du dossier \`queries\`${NC}"
+echo -e "${YELLOW}  tools/utils/install-sql-scripts.sh queries${NC}"
 tools/utils/install-sql-scripts.sh queries 
+echo " "
 
-# Exporte les tables de production restantes vers Metabase
+echo -e "${CYAN}→ Export des tables de production restantes vers Metabase${NC}"
+echo -e "${YELLOW}  tools/utils/export-db-metabase.sh${NC}"
 tools/utils/export-db-metabase.sh
+echo " "
 
-# Synchronise le schéma de la base de données
+echo -e "${CYAN}→ Synchronisation du schéma de la base de données dans Metabase${NC}"
+echo -e "${YELLOW}  tools/utils/sync-metabase-schemas.sh${NC}"
 tools/utils/sync-metabase-schemas.sh
+echo " "
+
+echo -e "${CYAN}→ Réactive les messages de niveau \"NOTICE\"${NC}"
+psql $METABASE_DB_URL -c "SET client_min_messages TO NOTICE;"
+echo " "

--- a/tools/utils/export-db-metabase.sh
+++ b/tools/utils/export-db-metabase.sh
@@ -5,5 +5,25 @@
 
 export DEST_DB_URL=$METABASE_DB_URL
 
+# Suppression en cascade et "à la main" de tables
+# L'instruction ci-dessous pg_dump $DATABASE_URL ... | psql -q $DEST_DB_URL ne
+# supprime pas corectement les tables, ce qui créée des doublons de données.
+psql $DEST_DB_URL -c "
+DO \$\$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT tablename
+        FROM pg_tables
+        WHERE tablename LIKE 'structures_%'
+        OR tablename LIKE 'stats_%'
+        OR tablename LIKE 'orientations_%'
+    LOOP
+        EXECUTE 'DROP TABLE ' || r.tablename || ' CASCADE';
+    END LOOP;
+END \$\$;
+"
+
 # Export des tables vers METABASE
 pg_dump $DATABASE_URL -O -c --if-exists -t orientations_* -t stats_*  -t structures_* -t services_servicesource -t services_bookmark -t services_servicefee -t services_accesscondition -t services_beneficiaryaccessmode -t services_coachorientationmode -t services_concernedpublic -t services_credential -t services_locationkind -t services_requirement -t services_service_access_conditions -t services_service_beneficiaries_access_modes -t services_service_categories -t services_service_coach_orientation_modes -t services_service_concerned_public -t services_service_credentials -t services_service_kinds -t services_service_location_kinds -t services_service_requirements -t services_service_subcategories -t services_servicecategory -t services_servicekind -t services_servicemodificationhistoryitem -t services_servicestatushistoryitem -t services_servicesubcategory -t services_savedsearch -t services_savedsearch_fees -t services_savedsearch_kinds -t services_savedsearch_subcategories  | psql -q $DEST_DB_URL

--- a/tools/utils/install-sql-scripts.sh
+++ b/tools/utils/install-sql-scripts.sh
@@ -62,13 +62,14 @@ function walkDirs() {
 
 	    echo "Suppression de '$tblname' sur la DB de destination"
 		drop_table_or_view_in_cascade_if_exists "$tblname"	    
-	    echo "--"
+	    echo " "
         fi
     done
     if [ -n "$tables_stmt" ]; then
 	    echo "Export du dump vers la DB de destination"
 	    pg_dump $SRC_DB_URL -O -c $tables_stmt | psql -q $DEST_DB_URL
 	    echo "Dump exporté"
+		echo " "
     fi
 }
 
@@ -83,5 +84,4 @@ if [ ! -d "$1" ]; then
 fi
 
 walkDirs "$1"
-echo "--"
-echo "✅ Terminé!"
+echo " "

--- a/tools/utils/sync-metabase-schemas.sh
+++ b/tools/utils/sync-metabase-schemas.sh
@@ -10,9 +10,6 @@
 #                               voir dans l'espace administrateur, rubrique : 'Bases de données'
 #                               l'ID est affiché dans l'URL
 
-
-echo "Synchronisation des schémas et champs Metabase"
-
 if [ -z ${METABASE_API_URL} ]; then
 	echo " > l'URL de l'API Metabase n'est pas défini"
 	exit 1


### PR DESCRIPTION
### 🍣 Contexte / problème

Nous nous sommes rendus compte récemment qu'il y a des soucis de doublons de données liées aux tables `stats_serviceview` et `stats_structureview`.

En plus d'afficher des métriques fausses, cela pollue le système jusqu'à rendre le dashboard "[Objectifs 2024](https://metabase.dora.inclusion.beta.gouv.fr/dashboard/92-objectifs-avril-sept-2024?tab=5-intention-de-mise-en-relation&d%25C3%25A9partement=&nb_de_fiches_de_services_mini=)" très lent et consommateur de ressources (CPU / RAM).

Par ailleurs, lors de la synchronisation, il y a pas mal d'autres petites erreurs qui remontent et gênent dans le monitoring et l'analyse des logs.

### 🦄 Solution

Faire en sorte de ne ne pas générer de doublons et corriger les petites erreurs faciles.

Côté production, nous avons supprimé le rôle en lecture seule `dora_back_ro_xxx`  qui n'était pas exploité mais que le `pg_dump + psql` cherchait tout de même à exploiter.

Côté code, je n'ai pas trouvé mieux que faire en boucle des `DROP TABLE ... CASCADE` en force (plutôt que par les options `-c --if-exists` pour corriger le problème. Le script obtenu a déjà été joué plusieurs fois avec succès sur la base Metabase.

Enfin, cette PR propose des petites améliorations visuelles au niveau des logs, pour simplifier encore plus la compréhension et le suivi.