### PR TITLE
Revert temporaire de la modification de l'API pour data·inclusion

### DIFF
--- a/dora/api/serializers.py
+++ b/dora/api/serializers.py
@@ -277,7 +277,8 @@ class ServiceSerializer(serializers.ModelSerializer):
         return [k.value for k in obj.kinds.all()]
 
     def get_thematiques(self, obj):
-        return [scat.value for scat in obj.subcategories.all()]
+        scats = [scat.value for scat in obj.subcategories.all()]
+        return [scat for scat in scats if not scat.endswith("--autre")]
 
     def get_prise_rdv(self, obj):
         return obj.appointment_link

--- a/dora/api/tests.py
+++ b/dora/api/tests.py
@@ -403,3 +403,25 @@ def test_service_serialization_exemple_need_di_user(api_client):
     response = api_client.get(f"/api/v2/services/{service.id}/")
 
     assert 401 == response.status_code
+
+
+def test_subcategories_other_excluded(authenticated_user, api_client):
+    # Example adapté de la doc data·inclusion :
+    # https://www.data.inclusion.beta.gouv.fr/schemas-de-donnees-de-loffre/schema-des-structures-et-services-dinsertion
+    structure = make_structure()
+    service = make_service(
+        structure=structure,
+        name="TISF",
+        short_desc="Accompagnement des familles à domicile",
+        fee_details="",
+        status=ServiceStatus.PUBLISHED,
+    )
+    service.subcategories.add(
+        ServiceSubCategory.objects.get(value="numerique--acceder-a-du-materiel")
+    )
+    service.subcategories.add(ServiceSubCategory.objects.get(value="numerique--autre"))
+
+    response = api_client.get(f"/api/v2/services/{service.id}/")
+
+    assert 200 == response.status_code
+    assert response.json().get("thematiques") == ["numerique--acceder-a-du-materiel"]


### PR DESCRIPTION
### 🍣 Contexte / problème

La PR #392 modifie les données envoyées par DORA à DI via l'API. 

Nous nous sommes mal synchronisés / organisés entre les 2 équipes.

Nous avons envoyé la modif alors que DI n'a pas fait la leur de leur côté.

Ça génère des erreurs et des services qui ne sont pas remontés dans DI.

### 🦄 Solution

Le temps de permettre à DI de faire le fix, nous proposons de rollback la modif.

### 🍿 Misc

This reverts commit ec4653e2d4d0a33be52425b11b6f7b2a25ffb26d.