### PR TITLE
[Onboarding] Log inutile en cas d'echec d'un retrait de liste "invité"

### DIFF
--- a/dora/onboarding/__init__.py
+++ b/dora/onboarding/__init__.py
@@ -278,6 +278,11 @@ def onboard_user(user: User, structure: Structure):
 
     # dans le cas d'un utilisateur passé membre, le retirer de la liste des invités
     if sib_list_id == int(settings.SIB_ONBOARDING_MEMBER_LIST):
-        _remove_from_sib_list(
-            client, user, int(settings.SIB_ONBOARDING_PUTATIVE_MEMBER_LIST)
-        )
+        if _contact_in_sib_list(client, user, sib_list_id):
+            # Dans le cas des imports via commande / script,
+            # les utilisateurs peuvent ne pas être passés par la liste "invité".
+            # Les retirer de la liste sans y vérifier leur présense provoque un log d'erreur,
+            # sans conséquence, mais qui alimente quand même les erreurs Sentry.
+            _remove_from_sib_list(
+                client, user, int(settings.SIB_ONBOARDING_PUTATIVE_MEMBER_LIST)
+            )

--- a/dora/onboarding/test.py
+++ b/dora/onboarding/test.py
@@ -73,6 +73,7 @@ def test_onboard_other_activities(
 @patch("dora.onboarding._remove_from_sib_list")
 @patch("dora.onboarding._create_or_update_sib_contact")
 @patch("dora.onboarding._setup_sib_client", Mock(return_value=True))
+@patch("dora.onboarding._contact_in_sib_list", Mock(return_value=True))
 def test_onboard_new_member(
     mock_create_contact,
     mock_remove_from_list,


### PR DESCRIPTION
Sans conséquence métier, mais inonde Sentry de faux positifs
