### PR TITLE
Amélioration de l'import SIRENE 

### DIFF
--- a/dora/sirene/backup.py
+++ b/dora/sirene/backup.py
@@ -1,3 +1,5 @@
+import random
+
 from django.db import connection, transaction
 
 from .models import Establishment
@@ -48,18 +50,22 @@ def create_table(table_name: str):
 
 
 def create_indexes(table_name: str):
+    def _suffix():
+        # pas de risque ici : cette table n'est pas utilisée par l'ORM Django
+        return f"{random.getrandbits(16*8):8x}"
+
     create_indexes_ddl = f"""
     CREATE INDEX {table_name}_full_text_trgm_idx ON public.{table_name} USING gin (full_search_text gin_trgm_ops);
-    CREATE INDEX {table_name}_code_commune_100bb2ad ON public.{table_name} USING btree (city_code);
-    CREATE INDEX {table_name}_code_commune_100bb2ad_like ON public.{table_name} USING btree (city_code varchar_pattern_ops);
-    CREATE INDEX {table_name}_is_siege_9c0272c3 ON public.{table_name} USING btree (is_siege);
-    CREATE INDEX {table_name}_name_d8569d90 ON public.{table_name} USING btree (name);
-    CREATE INDEX {table_name}_name_d8569d90_like ON public.{table_name} USING btree (name varchar_pattern_ops);
-    CREATE INDEX {table_name}_parent_name_1990928d ON public.{table_name} USING btree (parent_name);
-    CREATE INDEX {table_name}_parent_name_1990928d_like ON public.{table_name} USING btree (parent_name varchar_pattern_ops);
-    CREATE INDEX {table_name}_siren_b19f551a ON public.{table_name} USING btree (siren);
-    CREATE INDEX {table_name}_siren_b19f551a_like ON public.{table_name} USING btree (siren varchar_pattern_ops);
-    CREATE INDEX {table_name}_siret_3eb91925_like ON public.{table_name} USING btree (siret varchar_pattern_ops);
+    CREATE INDEX {table_name}_code_commune_{_suffix()} ON public.{table_name} USING btree (city_code);
+    CREATE INDEX {table_name}_code_commune_{_suffix()}_like ON public.{table_name} USING btree (city_code varchar_pattern_ops);
+    CREATE INDEX {table_name}_is_siege_{_suffix()} ON public.{table_name} USING btree (is_siege);
+    CREATE INDEX {table_name}_name_{_suffix()} ON public.{table_name} USING btree (name);
+    CREATE INDEX {table_name}_name_{_suffix()}_like ON public.{table_name} USING btree (name varchar_pattern_ops);
+    CREATE INDEX {table_name}_parent_name_{_suffix()} ON public.{table_name} USING btree (parent_name);
+    CREATE INDEX {table_name}_parent_name_{_suffix()}_like ON public.{table_name} USING btree (parent_name varchar_pattern_ops);
+    CREATE INDEX {table_name}_siren_{_suffix()} ON public.{table_name} USING btree (siren);
+    CREATE INDEX {table_name}_siren_{_suffix()}_like ON public.{table_name} USING btree (siren varchar_pattern_ops);
+    CREATE INDEX {table_name}_siret_{_suffix()}_like ON public.{table_name} USING btree (siret varchar_pattern_ops);
     """
     with connection.cursor() as c:
         c.execute(create_indexes_ddl)

--- a/dora/sirene/management/commands/import_sirene.py
+++ b/dora/sirene/management/commands/import_sirene.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
             the_dir = pathlib.Path(tmp_dir_name)
         else:
             the_dir = pathlib.Path("/tmp")
-        self.stdout.write("Saving SIRENE files to " + str(the_dir))
+        self.stdout.write("Sauvegarde des fichiers SIRENE dans : " + str(the_dir))
 
         legal_units_file_url = (
             "https://files.data.gouv.fr/insee-sirene/StockUniteLegale_utf8.zip"
@@ -68,13 +68,13 @@ class Command(BaseCommand):
         zipped_stock_file = the_dir / "StockUniteLegale_utf8.zip"
 
         if not os.path.exists(zipped_stock_file):
-            self.stdout.write(self.style.NOTICE("Downloading legal units file"))
+            self.stdout.write(self.style.NOTICE("Téléchargement des 'unités légales' (entreprises mères)"))
             subprocess.run(
                 ["curl", legal_units_file_url, "-o", zipped_stock_file],
                 check=True,
             )
 
-            self.stdout.write(self.style.NOTICE("Unzipping legal units file"))
+            self.stdout.write(self.style.NOTICE("Décompression fichier unités légales"))
             subprocess.run(
                 ["unzip", zipped_stock_file, "-d", the_dir],
                 check=True,
@@ -86,13 +86,13 @@ class Command(BaseCommand):
         gzipped_estab_file = the_dir / "StockEtablissementActif_utf8_geo.csv.gz"
 
         if not os.path.exists(gzipped_estab_file):
-            self.stdout.write(self.style.NOTICE("Downloading establishments file"))
+            self.stdout.write(self.style.NOTICE("Télécharchement des établissements"))
             subprocess.run(
                 ["curl", establishments_geo_file_url, "-o", gzipped_estab_file],
                 check=True,
             )
 
-            self.stdout.write(self.style.NOTICE("Unzipping establishments file"))
+            self.stdout.write(self.style.NOTICE("Décompression du fichier établissements"))
             subprocess.run(
                 ["gzip", "-dk", gzipped_estab_file],
                 check=True,
@@ -162,7 +162,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        if args.get("activate"):
+        if options.get("activate"):
             # activation de la table temporaire (si existante),
             # comme table de production (`sirene_establishment`)
             self.stdout.write(self.WARNING("Activation de la table de travail"))
@@ -178,21 +178,21 @@ class Command(BaseCommand):
             self.stdout.write(self.NOTICE("Activation terminée"))
             return
 
-        if args.get("rollback"):
+        if options.get("rollback"):
             # activation de la table sauvegardée
             self.stdout.write(self.WARNING("Activation de la table sauvegardée"))
             rename_table(SIRENE_TABLE, TMP_TABLE)
             rename_table(BACKUP_TABLE, SIRENE_TABLE)
             rename_table(TMP_TABLE, BACKUP_TABLE)
 
-        if args.get("analyse"):
+        if options.get("analyse"):
             # lance une analyse statistique sur la base Postgres
-            self.stdout.write(self.WARNING("Analyse de la DB en cours..."))
+            self.stdout.write(self.style.WARNING("Analyse de la DB en cours..."))
             vacuum_analyze()
-            self.stdout.write(self.NOTICE("Analyse terminée"))
+            self.stdout.write(self.style.NOTICE("Analyse terminée"))
             return
 
-        self.stdout.write(self.NOTICE(" > création de la base de travail"))
+        self.stdout.write(self.style.NOTICE(" > création de la base de travail"))
         # efface la précédente
         create_table(TMP_TABLE)
 


### PR DESCRIPTION
Quelques corrections et ajout d'une commande de nettoyage post-import.

L'étape suivante sera une connexion directe à la base cible pour y créer la table des établissements.

On évitera d'avoir à passer par un dump, et on pourra éventuellement passer à une phase d'automatisation, 
SI les temps de traitement n'est pas trop long (problème de TTL des instances scalingo). 

- **fix: typos, styles et textes en français**
- **fix: ajout de suffixes dynamiques pour les indexes**
- **Ajout d'une sous-commande de nettoyage (clean)**
