### PR TITLE
Correctif du mapping de thématiques DORA-DI

### DIFF
--- a/dora/data_inclusion/constants.py
+++ b/dora/data_inclusion/constants.py
@@ -11,5 +11,4 @@ THEMATIQUES_MAPPING_DI_TO_DORA = {
 # À une thématique Dora correspond une liste de thématiques DI
 THEMATIQUES_MAPPING_DORA_TO_DI = defaultdict(list)
 for key, value in THEMATIQUES_MAPPING_DI_TO_DORA.items():
-    if not value.endswith("--autre"):
-        THEMATIQUES_MAPPING_DORA_TO_DI[value].append(key)
+    THEMATIQUES_MAPPING_DORA_TO_DI[value].append(key)

--- a/dora/data_inclusion/tests.py
+++ b/dora/data_inclusion/tests.py
@@ -1,4 +1,6 @@
-from .constants import THEMATIQUES_MAPPING_DI_TO_DORA, THEMATIQUES_MAPPING_DORA_TO_DI
+import pytest
+
+from .constants import THEMATIQUES_MAPPING_DI_TO_DORA
 from .mappings import map_service
 from .test_utils import FakeDataInclusionClient, make_di_service_data
 
@@ -23,14 +25,28 @@ def test_map_service_thematiques_mapping():
     assert sorted(service["subcategories"]) == sorted(expected_subcategories)
 
 
-def test_di_client_search_thematiques_mapping():
-    input_thematique = list(THEMATIQUES_MAPPING_DORA_TO_DI.keys())[0]
-    output_thematique = list(THEMATIQUES_MAPPING_DORA_TO_DI.values())[0][0]
-
+@pytest.mark.parametrize(
+    "thematiques_dora, thematiques_di",
+    [
+        (
+            ["logement-hebergement--etre-accompagne-pour-se-loger"],
+            ["logement-hebergement--etre-accompagne-dans-son-projet-accession"],
+        ),
+        (
+            ["logement-hebergement--gerer-son-budget"],
+            ["logement-hebergement--etre-accompagne-en cas-de-difficultes-financieres"],
+        ),
+        (
+            ["logement-hebergement--autre"],
+            ["logement-hebergement--financer-son-projet-travaux"],
+        ),
+    ],
+)
+def test_di_client_search_thematiques_mapping(thematiques_dora, thematiques_di):
     di_client = FakeDataInclusionClient()
-    di_service_data = make_di_service_data(thematiques=[output_thematique])
+    di_service_data = make_di_service_data(thematiques=thematiques_di)
     di_client.services.append(di_service_data)
 
-    results = di_client.search_services(thematiques=[input_thematique])
+    results = di_client.search_services(thematiques=thematiques_dora)
 
     assert len(results) == 1

--- a/dora/services/search.py
+++ b/dora/services/search.py
@@ -15,6 +15,7 @@ import dora.services.models as models
 from dora import data_inclusion
 from dora.admin_express.models import City
 from dora.core.constants import WGS84
+from dora.data_inclusion.constants import THEMATIQUES_MAPPING_DORA_TO_DI
 from dora.structures.models import Structure
 
 from .constants import EXCLUDED_DI_SERVICES_THEMATIQUES
@@ -124,10 +125,19 @@ def _get_di_results(
     if categories is not None:
         thematiques += categories
     if subcategories is not None:
-        thematiques += [subcat for subcat in subcategories if "--autre" not in subcat]
+        # Les sous-catégories --autre ne sont conservées comme thématiques que lorsqu'elles
+        # sont présentes dans la table de correspondance de thématiques DORA vers DI.
+        # La correspondance sera faite plus tard, dans DataInclusionClient.search_services().
+        thematiques += [
+            subcat
+            for subcat in subcategories
+            if ("--autre" not in subcat or subcat in THEMATIQUES_MAPPING_DORA_TO_DI)
+        ]
 
-    # Si on recherche uniquement des sous-catégories `autre`, la liste des thématiques va être vide et d·i renverrait
-    # *tous* les services. On renvoie donc plutôt une liste vide.
+    # Si on recherche uniquement des sous-catégories `autre` qui n'ont pas de correspondances
+    # de thématiques DORA vers DI (THEMATIQUES_MAPPING_DORA_TO_DI), la liste des thématiques
+    # va être vide et d·i renverrait *tous* les services.
+    # On renvoie donc plutôt une liste vide.
     if not thematiques and subcategories:
         return []
 


### PR DESCRIPTION
Il y avait un filtre sur les sous-catégories `--autre` que je n'avais pas vu. Il faisait qu'aucun appel à DI n'était fait lorsqu'une telle sous-catégorie était sélectionnée.

Maintenant qu'on a un mapping de certaines thématiques vers notre sous-catégorie `logement-hebergement--autre`, il faut faire le même mapping dans l'autre sens, lors de l'appel à DI.

Je laisse donc passer les sous-catégories `--autre` dans le mapping DORA vers DI. Le mapping est encuite correctement effectué par le code précédemment écrit dans le client DI.