### PR TITLE
Exclusion des services de structures obsolètes lors de la recherche

### DIFF
--- a/dora/services/search.py
+++ b/dora/services/search.py
@@ -256,6 +256,9 @@ def _get_dora_results(
         )
     )
 
+    # On exclus les services dont la structure est marquèe comme obsolète
+    services = services.exclude(structure__is_obsolete=True)
+
     # Par souci de qualité des données,
     # les services DORA rattachés à une structure orpheline
     # sont filtrés lors de la recherche.


### PR DESCRIPTION
Quand une structure est indiquée comme obsolète par un gestionnaire ou par nous, on ne souhaite pas que les services qu’elle propose soient affichés dans les résultats de recherche.

- AJout d'un filtre dans la fonction de recherche de services DORA `_get_dora_results()` ;
- Ajout d'un test du filtrage des services de structure obsolète `test_search_services_with_obsolete_structure()`.